### PR TITLE
[codex] Add API workflow and release automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Release
+
+- Version label added, for example `v0.6`
+- After merge, GitHub Actions will create the matching git tag and release

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,61 @@
+name: API
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  api-core:
+    name: API core checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: json
+          coverage: none
+
+      - name: Validate Composer config
+        run: composer validate --strict --no-check-publish
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Dump autoload
+        run: composer dump-autoload
+
+      - name: Lint PHP files
+        run: find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Run API core tests
+        run: composer test
+
+      - name: Verify route list command
+        run: php shift.php route:list
+
+  version-label:
+    name: Version label required
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Require version label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            const versionLabels = labels.filter((name) => /^v\d+\.\d+(\.\d+)?$/.test(name));
+
+            if (versionLabels.length !== 1) {
+              core.setFailed(`Pull request must have exactly one version label like v0.6. Found: ${versionLabels.join(', ') || 'none'}`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release:
+    name: Create release after versioned PR merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Resolve version label
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            const versionLabels = labels.filter((name) => /^v\d+\.\d+(\.\d+)?$/.test(name));
+
+            if (versionLabels.length !== 1) {
+              core.setFailed(`Merged pull request must have exactly one version label like v0.6. Found: ${versionLabels.join(', ') || 'none'}`);
+              return;
+            }
+
+            core.setOutput('tag', versionLabels[0]);
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists locally."
+            exit 0
+          fi
+          git tag "${{ steps.version.outputs.tag }}" "${{ github.event.pull_request.merge_commit_sha }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.version.outputs.tag }}';
+            const pr = context.payload.pull_request;
+
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: `ShiftPHP ${tag}`,
+                target_commitish: pr.merge_commit_sha,
+                body: [
+                  `Release generated from PR #${pr.number}: ${pr.title}`,
+                  '',
+                  pr.html_url,
+                ].join('\n'),
+                draft: false,
+                prerelease: false,
+              });
+            } catch (error) {
+              if (error.status === 422) {
+                core.info(`Release ${tag} already exists.`);
+                return;
+              }
+
+              throw error;
+            }

--- a/README.md
+++ b/README.md
@@ -118,3 +118,9 @@ Run the lightweight API core test suite:
 ```sh
 composer test
 ```
+
+## Release Process
+
+Every pull request must have exactly one version label, for example `v0.6`.
+
+After a versioned PR is merged into `master`, GitHub Actions creates the matching git tag and GitHub Release automatically.


### PR DESCRIPTION
## Summary

Adds GitHub workflow automation for the API-only framework line:

- API workflow for Composer validation, PHP lint, API core tests, and route:list smoke
- PR version-label gate requiring exactly one label like v0.6
- release workflow that creates the matching git tag and GitHub Release after a versioned PR is merged
- PR template documenting validation and release requirements
- README release-process note

## Validation

- composer validate --strict --no-check-publish
- composer dump-autoload
- find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- php shift.php route:list