### PR TITLE
[codex] Use PR summary for release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 -
 
+<!-- The Release workflow uses this Summary section as release notes after merge. -->
+
 ## Validation
 
 -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,24 @@ jobs:
           script: |
             const tag = '${{ steps.version.outputs.tag }}';
             const pr = context.payload.pull_request;
+            const extractSection = (body, heading) => {
+              const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const pattern = new RegExp(`(?:^|\\n)##\\s+${escapedHeading}\\s*\\n([\\s\\S]*?)(?=\\n##\\s+|$)`, 'i');
+              const match = body.match(pattern);
+
+              return match ? match[1].trim() : '';
+            };
+            const summary = extractSection(pr.body || '', 'Summary');
+            const releaseChanges = summary || (pr.body || '').trim() || `- ${pr.title}`;
+            const releaseBody = [
+              '## Changes',
+              '',
+              releaseChanges,
+              '',
+              '## Pull request',
+              '',
+              `#${pr.number}: ${pr.html_url}`,
+            ].join('\n');
 
             try {
               await github.rest.repos.createRelease({
@@ -64,11 +82,7 @@ jobs:
                 tag_name: tag,
                 name: `ShiftPHP ${tag}`,
                 target_commitish: pr.merge_commit_sha,
-                body: [
-                  `Release generated from PR #${pr.number}: ${pr.title}`,
-                  '',
-                  pr.html_url,
-                ].join('\n'),
+                body: releaseBody,
                 draft: false,
                 prerelease: false,
               });


### PR DESCRIPTION
## Summary

- update release workflow to build GitHub Release notes from the merged PR Summary section
- keep a PR link below the generated Changes section
- document in the PR template that Summary is the source for release notes

## Validation

- tested Summary extraction locally with Node
- reviewed release workflow diff

## Release

- Version label added: v0.7