### PR TITLE
[codex] Add PHP attribute routing

### DIFF
--- a/Engine/Routing/AttributeRouteLoader.php
+++ b/Engine/Routing/AttributeRouteLoader.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Engine\Routing;
+
+use Engine\Router;
+use Engine\Routing\Attributes\Route;
+use Engine\Routing\Attributes\RoutePrefix;
+use ReflectionClass;
+
+class AttributeRouteLoader
+{
+    /**
+     * @param class-string[] $controllerClasses
+     */
+    public function load(Router $router, array $controllerClasses): void
+    {
+        foreach ($controllerClasses as $controllerClass) {
+            if (!class_exists($controllerClass)) {
+                continue;
+            }
+
+            $this->loadControllerRoutes($router, $controllerClass);
+        }
+    }
+
+    /**
+     * @param class-string $controllerClass
+     */
+    private function loadControllerRoutes(Router $router, string $controllerClass): void
+    {
+        $reflectionClass = new ReflectionClass($controllerClass);
+        $prefix = $this->getPrefix($reflectionClass);
+
+        foreach ($reflectionClass->getMethods() as $method) {
+            foreach ($method->getAttributes(Route::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                /** @var Route $route */
+                $route = $attribute->newInstance();
+
+                $router->add(
+                    $route->method,
+                    $this->joinPaths($prefix, $route->path),
+                    [$controllerClass, $method->getName()]
+                );
+            }
+        }
+    }
+
+    private function getPrefix(ReflectionClass $reflectionClass): string
+    {
+        $attributes = $reflectionClass->getAttributes(RoutePrefix::class);
+
+        if ($attributes === []) {
+            return '';
+        }
+
+        /** @var RoutePrefix $prefix */
+        $prefix = $attributes[0]->newInstance();
+
+        return $prefix->path;
+    }
+
+    private function joinPaths(string $prefix, string $path): string
+    {
+        $joined = trim($prefix, '/') . '/' . trim($path, '/');
+        $joined = '/' . trim($joined, '/');
+
+        return $joined === '/' ? '/' : rtrim($joined, '/');
+    }
+}

--- a/Engine/Routing/Attributes/Delete.php
+++ b/Engine/Routing/Attributes/Delete.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Delete extends Route
+{
+    public function __construct(string $path)
+    {
+        parent::__construct('DELETE', $path);
+    }
+}

--- a/Engine/Routing/Attributes/Get.php
+++ b/Engine/Routing/Attributes/Get.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Get extends Route
+{
+    public function __construct(string $path)
+    {
+        parent::__construct('GET', $path);
+    }
+}

--- a/Engine/Routing/Attributes/Patch.php
+++ b/Engine/Routing/Attributes/Patch.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Patch extends Route
+{
+    public function __construct(string $path)
+    {
+        parent::__construct('PATCH', $path);
+    }
+}

--- a/Engine/Routing/Attributes/Post.php
+++ b/Engine/Routing/Attributes/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Post extends Route
+{
+    public function __construct(string $path)
+    {
+        parent::__construct('POST', $path);
+    }
+}

--- a/Engine/Routing/Attributes/Put.php
+++ b/Engine/Routing/Attributes/Put.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Put extends Route
+{
+    public function __construct(string $path)
+    {
+        parent::__construct('PUT', $path);
+    }
+}

--- a/Engine/Routing/Attributes/Route.php
+++ b/Engine/Routing/Attributes/Route.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Route
+{
+    public function __construct(
+        public readonly string $method,
+        public readonly string $path
+    ) {
+    }
+}

--- a/Engine/Routing/Attributes/RoutePrefix.php
+++ b/Engine/Routing/Attributes/RoutePrefix.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class RoutePrefix
+{
+    public function __construct(public readonly string $path)
+    {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Routes are registered in `application/routes.php`:
 ```php
 use Controllers\HelloController;
 use Engine\Router;
+use Engine\Routing\AttributeRouteLoader;
 
 return static function (Router $router): void {
-    $router->get('/hello', [HelloController::class, 'index']);
-    $router->get('/hello/api/{argument}', [HelloController::class, 'api']);
-    $router->post('/hello/echo', [HelloController::class, 'echo']);
+    (new AttributeRouteLoader())->load($router, [
+        HelloController::class,
+    ]);
 };
 ```
 
@@ -49,9 +50,14 @@ namespace Controllers;
 use Engine\Controller;
 use Engine\JsonResponse;
 use Engine\Request;
+use Engine\Routing\Attributes\Get;
+use Engine\Routing\Attributes\Post;
+use Engine\Routing\Attributes\RoutePrefix;
 
+#[RoutePrefix('/users')]
 class UserController extends Controller
 {
+    #[Get('/{id}')]
     public function show(Request $request, string $id): JsonResponse
     {
         return $this->json([
@@ -59,10 +65,25 @@ class UserController extends Controller
             'include' => $request->query('include'),
         ]);
     }
+
+    #[Post('')]
+    public function create(Request $request): JsonResponse
+    {
+        return $this->json($request->getJson(), 201);
+    }
 }
 ```
 
 Route parameters are passed by method parameter name. A controller action can also request the current `Engine\Request`.
+
+You can use these routing attributes:
+
+- `#[RoutePrefix('/prefix')]`
+- `#[Get('/path')]`
+- `#[Post('/path')]`
+- `#[Put('/path')]`
+- `#[Patch('/path')]`
+- `#[Delete('/path')]`
 
 ## Responses
 

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -16,6 +16,7 @@ Implemented in this branch:
 - `405 Method Not Allowed` with an `Allow` header,
 - lightweight API core tests through `composer test`,
 - `route:list` CLI command,
+- PHP 8 attributes for controller routing,
 - removal of view storage and example page assets from runtime.
 
 ## Runtime Flow
@@ -35,8 +36,9 @@ Routes live in `application/routes.php`:
 
 ```php
 return static function (Router $router): void {
-    $router->get('/hello', [HelloController::class, 'index']);
-    $router->get('/hello/api/{argument}', [HelloController::class, 'api']);
+    (new AttributeRouteLoader())->load($router, [
+        HelloController::class,
+    ]);
 };
 ```
 
@@ -55,6 +57,7 @@ Controllers receive the current `Request` and `ServiceContainer` through the con
 ```php
 class HelloController extends \Engine\Controller
 {
+    #[Get('/api/{argument}')]
     public function api(string $argument): JsonResponse
     {
         return $this->json([

--- a/application/controller/HelloController.php
+++ b/application/controller/HelloController.php
@@ -5,13 +5,18 @@ namespace Controllers;
 use Engine\Controller;
 use Engine\JsonResponse;
 use Engine\Request;
+use Engine\Routing\Attributes\Get;
+use Engine\Routing\Attributes\Post;
+use Engine\Routing\Attributes\RoutePrefix;
 
 /**
  * Class HelloController
  * @package Controllers
  */
+#[RoutePrefix('/hello')]
 class HelloController extends Controller
 {
+    #[Get('')]
     public function index(): JsonResponse
     {
         return $this->json([
@@ -20,6 +25,7 @@ class HelloController extends Controller
         ]);
     }
 
+    #[Get('/about')]
     public function about(): JsonResponse
     {
         return $this->json([
@@ -28,6 +34,8 @@ class HelloController extends Controller
         ]);
     }
 
+    #[Get('/api')]
+    #[Get('/api/{argument}')]
     public function api(?string $argument = null): JsonResponse
     {
         $arguments = [];
@@ -47,6 +55,7 @@ class HelloController extends Controller
         ]);
     }
 
+    #[Post('/echo')]
     public function echo(Request $request): JsonResponse
     {
         return $this->json([

--- a/application/routes.php
+++ b/application/routes.php
@@ -2,11 +2,10 @@
 
 use Controllers\HelloController;
 use Engine\Router;
+use Engine\Routing\AttributeRouteLoader;
 
 return static function (Router $router): void {
-    $router->get('/hello', [HelloController::class, 'index']);
-    $router->get('/hello/about', [HelloController::class, 'about']);
-    $router->get('/hello/api', [HelloController::class, 'api']);
-    $router->get('/hello/api/{argument}', [HelloController::class, 'api']);
-    $router->post('/hello/echo', [HelloController::class, 'echo']);
+    (new AttributeRouteLoader())->load($router, [
+        HelloController::class,
+    ]);
 };

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -7,6 +7,7 @@ use Engine\JsonResponse;
 use Engine\Request;
 use Engine\ResponseEmitter;
 use Engine\Router;
+use Engine\Routing\AttributeRouteLoader;
 
 require_once __DIR__ . '/../bootstrap.php';
 
@@ -61,6 +62,28 @@ $tests['router matches route params'] = function (): void {
     $match = $router->match(makeRequest('GET', '/hello/api/example'));
 
     assertSameValue(['argument' => 'example'], $match->getParameters(), 'Route parameters should be extracted.');
+};
+
+$tests['attribute loader registers controller routes'] = function (): void {
+    $router = new Router();
+    (new AttributeRouteLoader())->load($router, [HelloController::class]);
+
+    $routes = array_map(
+        static fn (\Engine\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
+        $router->getRoutes()
+    );
+
+    assertSameValue(
+        [
+            'GET /hello',
+            'GET /hello/about',
+            'GET /hello/api',
+            'GET /hello/api/{argument}',
+            'POST /hello/echo',
+        ],
+        $routes,
+        'Attribute loader should register all HelloController routes.'
+    );
 };
 
 $tests['router returns 405 with Allow header'] = function (): void {


### PR DESCRIPTION
## Summary

- add PHP 8 attribute classes for API routing: RoutePrefix, Get, Post, Put, Patch, Delete
- add AttributeRouteLoader to register controller routes from method attributes
- migrate HelloController routes from manual route declarations to attributes
- keep application/routes.php as the routing composition point
- update route:list and API core tests to cover attribute-discovered routes
- document attribute-based routing in README and refactoring notes

## Validation

- composer dump-autoload
- find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- php shift.php route:list
- HTTP smoke tests:
  - GET /hello/api/foo -> 200 application/json
  - POST /hello/echo -> 200 application/json
  - POST /hello/api/foo -> 405 application/json with Allow: GET

## Release

- Version label added: v0.7.1