### PR TITLE
Expand PHP attribute support

### DIFF
--- a/Engine/App.php
+++ b/Engine/App.php
@@ -3,9 +3,15 @@
 namespace Engine;
 
 use Engine\Error\HttpError;
+use Engine\Routing\Attributes\Body;
+use Engine\Routing\Attributes\Header;
+use Engine\Routing\Attributes\PathParam;
+use Engine\Routing\Attributes\QueryParam;
+use Engine\Routing\Attributes\Status;
 use JsonException;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 use Throwable;
@@ -75,7 +81,10 @@ final class App
             $this->resolveMethodArguments($method->getParameters(), $match->getParameters())
         );
 
-        return $this->normalizeResponse($result);
+        return $this->applyResponseAttributes(
+            $this->normalizeResponse($result),
+            $method
+        );
     }
 
     /**
@@ -94,13 +103,43 @@ final class App
                 continue;
             }
 
+            $pathParam = $this->getParameterAttribute($parameter, PathParam::class);
+            if ($pathParam instanceof PathParam) {
+                $name = $pathParam->name ?? $parameter->getName();
+                $arguments[] = $this->castParameterValue(
+                    $routeParameters[$name] ?? $this->getDefaultParameterValue($parameter),
+                    $parameter
+                );
+                continue;
+            }
+
+            $queryParam = $this->getParameterAttribute($parameter, QueryParam::class);
+            if ($queryParam instanceof QueryParam) {
+                $name = $queryParam->name ?? $parameter->getName();
+                $arguments[] = $this->castParameterValue(
+                    $this->request->query($name, $queryParam->default ?? $this->getDefaultParameterValue($parameter)),
+                    $parameter
+                );
+                continue;
+            }
+
+            $body = $this->getParameterAttribute($parameter, Body::class);
+            if ($body instanceof Body) {
+                $json = $this->request->getJson();
+                $value = $body->key === null
+                    ? $json
+                    : ($json[$body->key] ?? $this->getDefaultParameterValue($parameter));
+                $arguments[] = $this->castParameterValue($value, $parameter);
+                continue;
+            }
+
             if (array_key_exists($parameter->getName(), $routeParameters)) {
-                $arguments[] = $routeParameters[$parameter->getName()];
+                $arguments[] = $this->castParameterValue($routeParameters[$parameter->getName()], $parameter);
                 continue;
             }
 
             if (array_key_exists($index, $orderedRouteParameters)) {
-                $arguments[] = $orderedRouteParameters[$index];
+                $arguments[] = $this->castParameterValue($orderedRouteParameters[$index], $parameter);
                 continue;
             }
 
@@ -113,6 +152,43 @@ final class App
         }
 
         return $arguments;
+    }
+
+    private function getParameterAttribute(ReflectionParameter $parameter, string $attributeClass): ?object
+    {
+        $attributes = $parameter->getAttributes($attributeClass);
+
+        if ($attributes === []) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    private function getDefaultParameterValue(ReflectionParameter $parameter): mixed
+    {
+        if ($parameter->isDefaultValueAvailable()) {
+            return $parameter->getDefaultValue();
+        }
+
+        return null;
+    }
+
+    private function castParameterValue(mixed $value, ReflectionParameter $parameter): mixed
+    {
+        $type = $parameter->getType();
+
+        if (!$type instanceof ReflectionNamedType || $value === null) {
+            return $value;
+        }
+
+        return match ($type->getName()) {
+            'int' => (int) $value,
+            'float' => (float) $value,
+            'bool' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            'string' => (string) $value,
+            default => $value,
+        };
     }
 
     /**
@@ -133,6 +209,31 @@ final class App
         }
 
         return new Response((string) $result);
+    }
+
+    private function applyResponseAttributes(Response $response, ReflectionMethod $method): Response
+    {
+        $statusCode = $response->getStatusCode();
+        $statusAttributes = $method->getAttributes(Status::class);
+
+        if ($statusAttributes !== []) {
+            /** @var Status $status */
+            $status = $statusAttributes[0]->newInstance();
+            $statusCode = $status->code;
+        }
+
+        $headers = $response->getHeaders();
+        foreach ($method->getAttributes(Header::class) as $attribute) {
+            /** @var Header $header */
+            $header = $attribute->newInstance();
+            $headers[$header->name] = $header->value;
+        }
+
+        return new Response(
+            $response->getContent(),
+            $statusCode,
+            $headers
+        );
     }
 
     /**

--- a/Engine/Routing/Attributes/Body.php
+++ b/Engine/Routing/Attributes/Body.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Body
+{
+    public function __construct(public readonly ?string $key = null)
+    {
+    }
+}

--- a/Engine/Routing/Attributes/Header.php
+++ b/Engine/Routing/Attributes/Header.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Header
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $value
+    ) {
+    }
+}

--- a/Engine/Routing/Attributes/PathParam.php
+++ b/Engine/Routing/Attributes/PathParam.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class PathParam
+{
+    public function __construct(public readonly ?string $name = null)
+    {
+    }
+}

--- a/Engine/Routing/Attributes/QueryParam.php
+++ b/Engine/Routing/Attributes/QueryParam.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class QueryParam
+{
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly mixed $default = null
+    ) {
+    }
+}

--- a/Engine/Routing/Attributes/Status.php
+++ b/Engine/Routing/Attributes/Status.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Engine\Routing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Status
+{
+    public function __construct(public readonly int $code)
+    {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -49,27 +49,33 @@ namespace Controllers;
 
 use Engine\Controller;
 use Engine\JsonResponse;
-use Engine\Request;
+use Engine\Routing\Attributes\Body;
 use Engine\Routing\Attributes\Get;
+use Engine\Routing\Attributes\Header;
 use Engine\Routing\Attributes\Post;
+use Engine\Routing\Attributes\PathParam;
+use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
+use Engine\Routing\Attributes\Status;
 
 #[RoutePrefix('/users')]
 class UserController extends Controller
 {
     #[Get('/{id}')]
-    public function show(Request $request, string $id): JsonResponse
+    public function show(#[PathParam] int $id, #[QueryParam('include')] ?string $include = null): JsonResponse
     {
         return $this->json([
             'id' => $id,
-            'include' => $request->query('include'),
+            'include' => $include,
         ]);
     }
 
     #[Post('')]
-    public function create(Request $request): JsonResponse
+    #[Status(201)]
+    #[Header('X-Resource', 'created')]
+    public function create(#[Body] array $payload): array
     {
-        return $this->json($request->getJson(), 201);
+        return $payload;
     }
 }
 ```
@@ -84,6 +90,11 @@ You can use these routing attributes:
 - `#[Put('/path')]`
 - `#[Patch('/path')]`
 - `#[Delete('/path')]`
+- `#[Status(201)]`
+- `#[Header('X-Name', 'value')]`
+- `#[PathParam('id')]`
+- `#[QueryParam('include')]`
+- `#[Body]` or `#[Body('field')]`
 
 ## Responses
 

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -17,6 +17,7 @@ Implemented in this branch:
 - lightweight API core tests through `composer test`,
 - `route:list` CLI command,
 - PHP 8 attributes for controller routing,
+- PHP 8 attributes for response metadata and parameter binding,
 - removal of view storage and example page assets from runtime.
 
 ## Runtime Flow
@@ -58,11 +59,19 @@ Controllers receive the current `Request` and `ServiceContainer` through the con
 class HelloController extends \Engine\Controller
 {
     #[Get('/api/{argument}')]
-    public function api(string $argument): JsonResponse
+    public function api(#[PathParam] string $argument, #[QueryParam('include')] ?string $include = null): JsonResponse
     {
         return $this->json([
             'argument' => $argument,
+            'include' => $include,
         ]);
+    }
+
+    #[Post('/created')]
+    #[Status(201)]
+    public function created(#[Body('name')] string $name): array
+    {
+        return ['name' => $name];
     }
 }
 ```

--- a/application/controller/HelloController.php
+++ b/application/controller/HelloController.php
@@ -4,10 +4,14 @@ namespace Controllers;
 
 use Engine\Controller;
 use Engine\JsonResponse;
-use Engine\Request;
 use Engine\Routing\Attributes\Get;
+use Engine\Routing\Attributes\Body;
+use Engine\Routing\Attributes\Header;
+use Engine\Routing\Attributes\PathParam;
 use Engine\Routing\Attributes\Post;
+use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
+use Engine\Routing\Attributes\Status;
 
 /**
  * Class HelloController
@@ -36,7 +40,7 @@ class HelloController extends Controller
 
     #[Get('/api')]
     #[Get('/api/{argument}')]
-    public function api(?string $argument = null): JsonResponse
+    public function api(#[PathParam] ?string $argument = null, #[QueryParam('include')] ?string $include = null): JsonResponse
     {
         $arguments = [];
         if ($argument !== null) {
@@ -50,16 +54,28 @@ class HelloController extends Controller
                 'path' => $this->request->getPath(),
                 'method' => $this->request->getMethod(),
                 'arguments' => $arguments,
+                'include' => $include,
                 'routeParams' => $this->request->getRouteParams()
             ]
         ]);
     }
 
     #[Post('/echo')]
-    public function echo(Request $request): JsonResponse
+    public function echo(#[Body] array $data): JsonResponse
     {
         return $this->json([
-            'data' => $request->getJson(),
+            'data' => $data,
         ]);
+    }
+
+    #[Post('/created')]
+    #[Status(201)]
+    #[Header('X-ShiftPHP-Example', 'created')]
+    public function created(#[Body('name')] string $name): array
+    {
+        return [
+            'name' => $name,
+            'created' => true,
+        ];
     }
 }

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -39,7 +39,7 @@ function assertArrayHasKeyValue(string $key, mixed $expected, array $actual, str
     }
 }
 
-function makeRequest(string $method, string $uri, string $body = ''): Request
+function makeRequest(string $method, string $uri, string $body = '', array $query = []): Request
 {
     return new Request(
         [
@@ -47,7 +47,7 @@ function makeRequest(string $method, string $uri, string $body = ''): Request
             'REQUEST_URI' => $uri,
             'HTTP_AUTHORIZATION' => 'Bearer token',
         ],
-        [],
+        $query,
         [],
         $body
     );
@@ -80,6 +80,7 @@ $tests['attribute loader registers controller routes'] = function (): void {
             'GET /hello/api',
             'GET /hello/api/{argument}',
             'POST /hello/echo',
+            'POST /hello/created',
         ],
         $routes,
         'Attribute loader should register all HelloController routes.'
@@ -142,6 +143,35 @@ $tests['app dispatches route to controller'] = function (): void {
 
     assertSameValue(200, $emitter->statusCode, 'App should emit successful status.');
     assertSameValue('demo', $payload['data']['routeParams']['argument'] ?? null, 'App should pass route params to controller.');
+};
+
+$tests['app binds path and query params from attributes'] = function (): void {
+    $router = new Router();
+    (new AttributeRouteLoader())->load($router, [HelloController::class]);
+    $emitter = new CapturingEmitter();
+
+    $app = new App(makeRequest('GET', '/hello/api/demo', '', ['include' => 'details']), $router, $emitter);
+    $app->start();
+
+    $payload = json_decode($emitter->content, true);
+
+    assertSameValue('demo', $payload['data']['arguments'][0] ?? null, 'PathParam should bind route value.');
+    assertSameValue('details', $payload['data']['include'] ?? null, 'QueryParam should bind query value.');
+};
+
+$tests['app applies status header and body attributes'] = function (): void {
+    $router = new Router();
+    (new AttributeRouteLoader())->load($router, [HelloController::class]);
+    $emitter = new CapturingEmitter();
+
+    $app = new App(makeRequest('POST', '/hello/created', '{"name":"Shift"}'), $router, $emitter);
+    $app->start();
+
+    $payload = json_decode($emitter->content, true);
+
+    assertSameValue(201, $emitter->statusCode, 'Status attribute should override response status.');
+    assertArrayHasKeyValue('X-ShiftPHP-Example', 'created', $emitter->headers, 'Header attribute should add response header.');
+    assertSameValue('Shift', $payload['name'] ?? null, 'Body attribute should bind JSON body key.');
 };
 
 $failed = 0;


### PR DESCRIPTION
## Summary

- add response metadata attributes: Status and Header
- add action parameter binding attributes: PathParam, QueryParam, and Body
- bind attributed route, query, and JSON body values in the controller dispatcher
- cast scalar bound values using action parameter types
- add example endpoints using status/header/body attributes
- extend API core tests for attribute parameter binding and response metadata
- update README and refactoring notes with the new attribute API

## Validation

- composer dump-autoload
- find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- php shift.php route:list
- HTTP smoke tests:
  - GET /hello/api/foo?include=details -> 200 application/json
  - POST /hello/created -> 201 application/json with X-ShiftPHP-Example: created
  - POST /hello/api/foo -> 405 application/json with Allow: GET

## Release

- Version label added: v0.7.6