### PR TITLE
Organize framework namespaces by domain

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -53,8 +53,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map((label) => label.name);
-            const versionLabels = labels.filter((name) => /^v\d+\.\d+(\.\d+)?$/.test(name));
+            const {owner, repo} = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const {data: labels} = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: pull_number,
+            });
+            const labelNames = labels.map((label) => label.name);
+            const versionLabels = labelNames.filter((name) => /^v\d+\.\d+(\.\d+)?$/.test(name));
 
             if (versionLabels.length !== 1) {
               core.setFailed(`Pull request must have exactly one version label like v0.6. Found: ${versionLabels.join(', ') || 'none'}`);

--- a/Engine/App.php
+++ b/Engine/App.php
@@ -3,6 +3,7 @@
 namespace Engine;
 
 use Engine\Error\HttpError;
+use Engine\Response\JsonResponse;
 use Engine\Response\Response;
 use Engine\Response\ResponseEmitter;
 use Engine\Routing\Attributes\Body;

--- a/Engine/App.php
+++ b/Engine/App.php
@@ -11,6 +11,7 @@ use Engine\Routing\Attributes\Header;
 use Engine\Routing\Attributes\PathParam;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\Status;
+use Engine\Service\ServiceContainer;
 use JsonException;
 use ReflectionClass;
 use ReflectionException;

--- a/Engine/App.php
+++ b/Engine/App.php
@@ -3,6 +3,8 @@
 namespace Engine;
 
 use Engine\Error\HttpError;
+use Engine\Response\Response;
+use Engine\Response\ResponseEmitter;
 use Engine\Routing\Attributes\Body;
 use Engine\Routing\Attributes\Header;
 use Engine\Routing\Attributes\PathParam;

--- a/Engine/App.php
+++ b/Engine/App.php
@@ -11,6 +11,7 @@ use Engine\Routing\Attributes\Header;
 use Engine\Routing\Attributes\PathParam;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\Status;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 use JsonException;
 use ReflectionClass;

--- a/Engine/Console/Commands/RouteList.php
+++ b/Engine/Console/Commands/RouteList.php
@@ -5,7 +5,7 @@ namespace Console\Commands;
 use Engine\Console\Cli;
 use Engine\Console\CommandInterface;
 use Engine\Modules\ModuleLoader;
-use Engine\Router;
+use Engine\Routing\Router\Router;
 
 class RouteList implements CommandInterface
 {

--- a/Engine/Controller.php
+++ b/Engine/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Engine;
 
+use Engine\Response\JsonResponse;
 use Engine\Response\Response;
 use JsonException;
 

--- a/Engine/Controller.php
+++ b/Engine/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Engine;
 
+use Engine\Response\Response;
 use JsonException;
 
 /**

--- a/Engine/Controller.php
+++ b/Engine/Controller.php
@@ -4,6 +4,7 @@ namespace Engine;
 
 use Engine\Response\JsonResponse;
 use Engine\Response\Response;
+use Engine\Service\ServiceContainer;
 use JsonException;
 
 /**

--- a/Engine/JsonResponse.php
+++ b/Engine/JsonResponse.php
@@ -2,6 +2,7 @@
 
 namespace Engine;
 
+use Engine\Response\Response;
 use JsonException;
 
 class JsonResponse extends Response

--- a/Engine/Modules/AbstractModule.php
+++ b/Engine/Modules/AbstractModule.php
@@ -2,7 +2,7 @@
 
 namespace Engine\Modules;
 
-use Engine\Router;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 
 abstract class AbstractModule implements ModuleInterface

--- a/Engine/Modules/AbstractModule.php
+++ b/Engine/Modules/AbstractModule.php
@@ -3,7 +3,7 @@
 namespace Engine\Modules;
 
 use Engine\Router;
-use Engine\ServiceContainer;
+use Engine\Service\ServiceContainer;
 
 abstract class AbstractModule implements ModuleInterface
 {

--- a/Engine/Modules/ModuleInterface.php
+++ b/Engine/Modules/ModuleInterface.php
@@ -3,7 +3,7 @@
 namespace Engine\Modules;
 
 use Engine\Router;
-use Engine\ServiceContainer;
+use Engine\Service\ServiceContainer;
 
 interface ModuleInterface
 {

--- a/Engine/Modules/ModuleInterface.php
+++ b/Engine/Modules/ModuleInterface.php
@@ -2,7 +2,7 @@
 
 namespace Engine\Modules;
 
-use Engine\Router;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 
 interface ModuleInterface

--- a/Engine/Modules/ModuleLoader.php
+++ b/Engine/Modules/ModuleLoader.php
@@ -3,7 +3,7 @@
 namespace Engine\Modules;
 
 use Engine\Router;
-use Engine\ServiceContainer;
+use Engine\Service\ServiceContainer;
 
 class ModuleLoader
 {

--- a/Engine/Modules/ModuleLoader.php
+++ b/Engine/Modules/ModuleLoader.php
@@ -2,7 +2,7 @@
 
 namespace Engine\Modules;
 
-use Engine\Router;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 
 class ModuleLoader

--- a/Engine/Response/JsonResponse.php
+++ b/Engine/Response/JsonResponse.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Engine;
+namespace Engine\Response;
 
-use Engine\Response\Response;
 use JsonException;
 
 class JsonResponse extends Response

--- a/Engine/Response/Response.php
+++ b/Engine/Response/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Engine;
+namespace Engine\Response;
 
 class Response
 {

--- a/Engine/Response/ResponseEmitter.php
+++ b/Engine/Response/ResponseEmitter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Engine;
+namespace Engine\Response;
 
 class ResponseEmitter
 {

--- a/Engine/Routing/AttributeRouteLoader.php
+++ b/Engine/Routing/AttributeRouteLoader.php
@@ -33,7 +33,7 @@ class AttributeRouteLoader
 
         foreach ($reflectionClass->getMethods() as $method) {
             foreach ($method->getAttributes(Route::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                /** @var \Engine\Routing\Router\Route $route */
+                /** @var Route $route */
                 $route = $attribute->newInstance();
 
                 $router->add(

--- a/Engine/Routing/AttributeRouteLoader.php
+++ b/Engine/Routing/AttributeRouteLoader.php
@@ -2,9 +2,9 @@
 
 namespace Engine\Routing;
 
-use Engine\Router;
 use Engine\Routing\Attributes\Route;
 use Engine\Routing\Attributes\RoutePrefix;
+use Engine\Routing\Router\Router;
 use ReflectionClass;
 
 class AttributeRouteLoader
@@ -33,7 +33,7 @@ class AttributeRouteLoader
 
         foreach ($reflectionClass->getMethods() as $method) {
             foreach ($method->getAttributes(Route::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                /** @var Route $route */
+                /** @var \Engine\Routing\Router\Route $route */
                 $route = $attribute->newInstance();
 
                 $router->add(

--- a/Engine/Routing/Router/Route.php
+++ b/Engine/Routing/Router/Route.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Engine;
+namespace Engine\Routing\Router;
+
+use Engine\Request;
 
 class Route
 {

--- a/Engine/Routing/Router/RouteMatch.php
+++ b/Engine/Routing/Router/RouteMatch.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Engine;
+namespace Engine\Routing\Router;
 
 readonly class RouteMatch
 {

--- a/Engine/Routing/Router/Router.php
+++ b/Engine/Routing/Router/Router.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Engine;
+namespace Engine\Routing\Router;
 
 use Engine\Error\HttpError;
+use Engine\Request;
 
 class Router
 {

--- a/Engine/Service/ServiceContainer.php
+++ b/Engine/Service/ServiceContainer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Engine;
+namespace Engine\Service;
 
 use Closure;
 use InvalidArgumentException;

--- a/Engine/Service/ServiceInterface.php
+++ b/Engine/Service/ServiceInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Engine;
+namespace Engine\Service;
 
 /**
  * Interface ServiceInterface

--- a/README.md
+++ b/README.md
@@ -177,12 +177,7 @@ A module registers itself through `Module.php`:
 ```php
 namespace Modules\Health;
 
-use Engine\Modules\AbstractModule;
-use Engine\Router;
-use Engine\Routing\AttributeRouteLoader;
-use Engine\ServiceContainer;
-use Modules\Health\Controllers\HealthController;
-use Modules\Health\Services\HealthService;
+use Engine\Modules\AbstractModule;use Engine\Router;use Engine\Routing\AttributeRouteLoader;use Engine\Service\ServiceContainer;use Modules\Health\Controllers\HealthController;use Modules\Health\Services\HealthService;
 
 class Module extends AbstractModule
 {

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Controllers extend `Engine\Controller` and return a response object:
 namespace Modules\Users\Controllers;
 
 use Engine\Controller;
-use Engine\JsonResponse;
+use Engine\Response\JsonResponse;
 use Engine\Routing\Attributes\Body;
 use Engine\Routing\Attributes\Get;
 use Engine\Routing\Attributes\Header;
-use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\PathParam;
+use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
 use Engine\Routing\Attributes\Status;

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ Routes are owned by modules and registered from each module boundary:
 ```php
 namespace Modules\Health;
 
-use Engine\Modules\AbstractModule;
-use Engine\Router;
-use Engine\Routing\AttributeRouteLoader;
-use Modules\Health\Controllers\HealthController;
+use Engine\Modules\AbstractModule;use Engine\Routing\AttributeRouteLoader;use Engine\Routing\Router\Router;use Modules\Health\Controllers\HealthController;
 
 class Module extends AbstractModule
 {
@@ -177,7 +174,7 @@ A module registers itself through `Module.php`:
 ```php
 namespace Modules\Health;
 
-use Engine\Modules\AbstractModule;use Engine\Router;use Engine\Routing\AttributeRouteLoader;use Engine\Service\ServiceContainer;use Modules\Health\Controllers\HealthController;use Modules\Health\Services\HealthService;
+use Engine\Modules\AbstractModule;use Engine\Routing\AttributeRouteLoader;use Engine\Routing\Router\Router;use Engine\Service\ServiceContainer;use Modules\Health\Controllers\HealthController;use Modules\Health\Services\HealthService;
 
 class Module extends AbstractModule
 {

--- a/application/modules/Health/Controllers/HealthController.php
+++ b/application/modules/Health/Controllers/HealthController.php
@@ -3,7 +3,7 @@
 namespace Modules\Health\Controllers;
 
 use Engine\Controller;
-use Engine\JsonResponse;
+use Engine\Response\JsonResponse;
 use Engine\Routing\Attributes\Get;
 use Engine\Routing\Attributes\RoutePrefix;
 use Modules\Health\Services\HealthService;

--- a/application/modules/Health/Module.php
+++ b/application/modules/Health/Module.php
@@ -5,7 +5,7 @@ namespace Modules\Health;
 use Engine\Modules\AbstractModule;
 use Engine\Router;
 use Engine\Routing\AttributeRouteLoader;
-use Engine\ServiceContainer;
+use Engine\Service\ServiceContainer;
 use Modules\Health\Controllers\HealthController;
 use Modules\Health\Services\HealthService;
 

--- a/application/modules/Health/Module.php
+++ b/application/modules/Health/Module.php
@@ -3,8 +3,8 @@
 namespace Modules\Health;
 
 use Engine\Modules\AbstractModule;
-use Engine\Router;
 use Engine\Routing\AttributeRouteLoader;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 use Modules\Health\Controllers\HealthController;
 use Modules\Health\Services\HealthService;

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -7,7 +7,6 @@ use Engine\Modules\ModuleLoader;
 use Engine\Request;
 use Engine\Response\JsonResponse;
 use Engine\Response\ResponseEmitter;
-use Engine\Router;
 use Engine\Routing\AttributeRouteLoader;
 use Engine\Routing\Attributes\Body;
 use Engine\Routing\Attributes\Get;
@@ -17,6 +16,7 @@ use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
 use Engine\Routing\Attributes\Status;
+use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 use Modules\Health\Services\HealthService;
 
@@ -112,7 +112,7 @@ $tests['attribute loader registers controller routes'] = function (): void {
     (new AttributeRouteLoader())->load($router, [TestAttributeController::class]);
 
     $routes = array_map(
-        static fn (\Engine\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
+        static fn (Router\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
         $router->getRoutes()
     );
 
@@ -224,7 +224,7 @@ $tests['module loader registers services and routes'] = function (): void {
     assertSameValue(true, $container->has(HealthService::class), 'Health module service should be registered.');
 
     $routes = array_map(
-        static fn (\Engine\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
+        static fn (Router\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
         $router->getRoutes()
     );
 

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -17,7 +17,7 @@ use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
 use Engine\Routing\Attributes\Status;
-use Engine\ServiceContainer;
+use Engine\Service\ServiceContainer;
 use Modules\Health\Services\HealthService;
 
 require_once __DIR__ . '/../bootstrap.php';

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -3,9 +3,9 @@
 use Engine\App;
 use Engine\Controller;
 use Engine\Error\HttpError;
-use Engine\JsonResponse;
 use Engine\Modules\ModuleLoader;
 use Engine\Request;
+use Engine\Response\JsonResponse;
 use Engine\Response\ResponseEmitter;
 use Engine\Router;
 use Engine\Routing\AttributeRouteLoader;

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -4,10 +4,10 @@ use Engine\App;
 use Engine\Controller;
 use Engine\Error\HttpError;
 use Engine\JsonResponse;
+use Engine\Modules\ModuleLoader;
 use Engine\Request;
-use Engine\ResponseEmitter;
+use Engine\Response\ResponseEmitter;
 use Engine\Router;
-use Engine\ServiceContainer;
 use Engine\Routing\AttributeRouteLoader;
 use Engine\Routing\Attributes\Body;
 use Engine\Routing\Attributes\Get;
@@ -17,7 +17,7 @@ use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
 use Engine\Routing\Attributes\Status;
-use Engine\Modules\ModuleLoader;
+use Engine\ServiceContainer;
 use Modules\Health\Services\HealthService;
 
 require_once __DIR__ . '/../bootstrap.php';
@@ -28,7 +28,7 @@ final class CapturingEmitter extends ResponseEmitter
     public array $headers = [];
     public string $content = '';
 
-    public function emit(\Engine\Response $response): void
+    public function emit(\Engine\Response\Response $response): void
     {
         $this->statusCode = $response->getStatusCode();
         $this->headers = $response->getHeaders();

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -16,6 +16,7 @@ use Engine\Routing\Attributes\Post;
 use Engine\Routing\Attributes\QueryParam;
 use Engine\Routing\Attributes\RoutePrefix;
 use Engine\Routing\Attributes\Status;
+use Engine\Routing\Router\Route;
 use Engine\Routing\Router\Router;
 use Engine\Service\ServiceContainer;
 use Modules\Health\Services\HealthService;
@@ -112,7 +113,7 @@ $tests['attribute loader registers controller routes'] = function (): void {
     (new AttributeRouteLoader())->load($router, [TestAttributeController::class]);
 
     $routes = array_map(
-        static fn (Router\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
+        static fn (Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
         $router->getRoutes()
     );
 
@@ -224,7 +225,7 @@ $tests['module loader registers services and routes'] = function (): void {
     assertSameValue(true, $container->has(HealthService::class), 'Health module service should be registered.');
 
     $routes = array_map(
-        static fn (Router\Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
+        static fn (Route $route): string => $route->getMethod() . ' ' . $route->getPath(),
         $router->getRoutes()
     );
 


### PR DESCRIPTION
## Summary

- Move response classes into the `Engine\Response` namespace and directory.
- Move router classes into the `Engine\Routing\Router` namespace and directory.
- Move service container contracts into the `Engine\Service` namespace and directory.
- Update app, module, CLI, tests, and README references to the new namespace layout.
- Fix route type imports after the router namespace refactor.
- Make the API workflow read live PR labels when validating the release version label.
- Mark completed roadmap items and next refactoring steps in `REFACTORING.md`.

## Validation

- `composer dump-autoload`
- `find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l`
- `composer test`
- `php shift.php route:list`
- `php shift.php health`
- HTTP smoke tests:
  - `GET /health -> 200 application/json`
  - `GET /hello -> 404 application/json`

## Release

- Version label: `v0.8.1`