### PR TITLE
Add controller autowiring

### DIFF
--- a/Engine/App.php
+++ b/Engine/App.php
@@ -100,7 +100,7 @@ final class App
             throw new HttpError('Endpoint not found', 404);
         }
 
-        $controller = new $controllerClass($request, $this->container);
+        $controller = $this->createController($controllerClass);
         $reflectionClass = new ReflectionClass($controller);
 
         if (!$reflectionClass->hasMethod($methodName)) {
@@ -117,6 +117,15 @@ final class App
             $this->normalizeResponse($result),
             $method
         );
+    }
+
+    private function createController(string $controllerClass): object
+    {
+        if ($this->container->has($controllerClass)) {
+            return $this->container->resolve($controllerClass);
+        }
+
+        return $this->container->make($controllerClass);
     }
 
     /**
@@ -306,7 +315,10 @@ final class App
     private function registerDefaultServices(): void
     {
         $this->container->singleton('request', $this->request);
+        $this->container->singleton(Request::class, $this->request);
         $this->container->singleton('router', $this->router);
+        $this->container->singleton(Router::class, $this->router);
+        $this->container->singleton(ServiceContainer::class, $this->container);
     }
 
     public function getContainer(): ServiceContainer

--- a/Engine/Service/ServiceContainer.php
+++ b/Engine/Service/ServiceContainer.php
@@ -4,6 +4,10 @@ namespace Shift\Service;
 
 use Closure;
 use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+use ReflectionParameter;
 
 /**
  * Class ServiceContainer
@@ -76,10 +80,68 @@ class ServiceContainer
         }
 
         if (is_string($service) && class_exists($service)) {
-            return new $service();
+            return $this->make($service);
         }
 
         return $service;
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @return T
+     */
+    public function make(string $class): object
+    {
+        if (!class_exists($class)) {
+            throw new InvalidArgumentException("Class '{$class}' not found");
+        }
+
+        try {
+            $reflectionClass = new ReflectionClass($class);
+        } catch (ReflectionException $exception) {
+            throw new InvalidArgumentException("Class '{$class}' cannot be reflected", 0, $exception);
+        }
+
+        if (!$reflectionClass->isInstantiable()) {
+            throw new InvalidArgumentException("Class '{$class}' is not instantiable");
+        }
+
+        $constructor = $reflectionClass->getConstructor();
+
+        if ($constructor === null) {
+            return new $class();
+        }
+
+        $dependencies = array_map(
+            fn (ReflectionParameter $parameter): mixed => $this->resolveParameter($parameter),
+            $constructor->getParameters()
+        );
+
+        return $reflectionClass->newInstanceArgs($dependencies);
+    }
+
+    private function resolveParameter(ReflectionParameter $parameter): mixed
+    {
+        $type = $parameter->getType();
+
+        if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+            $name = $type->getName();
+
+            if ($this->has($name)) {
+                return $this->resolve($name);
+            }
+
+            if (class_exists($name)) {
+                return $this->make($name);
+            }
+        }
+
+        if ($parameter->isDefaultValueAvailable()) {
+            return $parameter->getDefaultValue();
+        }
+
+        throw new InvalidArgumentException("Unable to resolve parameter '{$parameter->getName()}'");
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ class UserController extends Controller
 
 Route parameters are passed by method parameter name. A controller action can also request the current `Shift\Request`.
 
+Controllers are created through the service container, so constructor dependencies can be type-hinted:
+
+```php
+class UserController extends Controller
+{
+    public function __construct(private readonly UserService $users)
+    {
+    }
+
+    #[Get('/{id}')]
+    public function show(#[PathParam] int $id): array
+    {
+        return $this->users->find($id);
+    }
+}
+```
+
 You can use these routing attributes:
 
 - `#[RoutePrefix('/prefix')]`
@@ -166,6 +183,16 @@ $app->middleware(function (Request $request, callable $next): Response {
         $response->getHeaders() + ['X-Api' => 'Shift']
     );
 });
+```
+
+## Service Container
+
+The container can resolve registered services and build classes with typed constructor dependencies:
+
+```php
+$container->singleton(UserService::class, UserService::class);
+$service = $container->resolve(UserService::class);
+$controller = $container->make(UserController::class);
 ```
 
 ## Run Locally

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -19,6 +19,7 @@ ShiftPHP is moving toward an API-only modular monolith. View templates, compiled
 - [x] Modular monolith support through `application/modules/*/Module.php`.
 - [x] Module-owned controllers, routes, services and commands.
 - [x] Middleware pipeline.
+- [x] Controller autowiring through the container.
 - [x] Removal of view storage and example page assets from runtime.
 - [x] Removal of legacy `application/controllers` and `application/routes.php`.
 - [x] Domain-oriented framework namespaces:
@@ -143,7 +144,6 @@ Internal errors return a generic `500` message unless `display_errors` is enable
 
 ## Next
 
-- [ ] Controller autowiring through the container.
 - [ ] Validation helpers and typed request DTOs.
 - [ ] CORS middleware.
 - [ ] Authentication and authorization middleware contracts.

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,7 +202,7 @@ final class UserController extends Controller
 
         <section id="controllers">
             <h2>Controllers</h2>
-            <p>Controllers extend <code>Shift\Controller</code>. The current <code>Shift\Request</code> and <code>Shift\Service\ServiceContainer</code> are injected through the constructor.</p>
+            <p>Controllers extend <code>Shift\Controller</code>. Controllers are created through the service container, so typed constructor dependencies can be injected automatically.</p>
 
             <p>Controller actions can return:</p>
             <ul>
@@ -221,6 +221,24 @@ final class UserController extends Controller
                 <li><code>$this-&gt;getRequest()</code></li>
                 <li><code>$this-&gt;getContainer()</code></li>
             </ul>
+
+            <h3>Constructor Autowiring</h3>
+            <p>Register services in a module, then type-hint them in a controller constructor.</p>
+
+            <pre><code>final class UserController extends Controller
+{
+    public function __construct(private readonly UserService $users)
+    {
+    }
+
+    #[Get('/{id}')]
+    public function show(#[PathParam] int $id): array
+    {
+        return $this-&gt;users-&gt;find($id);
+    }
+}</code></pre>
+
+            <p>The app registers the current <code>Shift\Request</code>, <code>Shift\Routing\Router\Router</code>, and <code>Shift\Service\ServiceContainer</code> in the container by default.</p>
         </section>
 
         <section id="requests">
@@ -302,16 +320,17 @@ final class AuthMiddleware implements MiddlewareInterface
 
         <section id="services">
             <h2>Service Container</h2>
-            <p><code>Shift\Service\ServiceContainer</code> stores regular services and singletons. It can resolve closures, class names, and already-created objects.</p>
+            <p><code>Shift\Service\ServiceContainer</code> stores regular services and singletons. It can resolve closures, class names, and already-created objects. It can also build classes with typed constructor dependencies.</p>
 
             <pre><code>$container-&gt;register(UserRepository::class, UserRepository::class);
 $container-&gt;singleton(HealthService::class, HealthService::class);
 $container-&gt;singleton('request', $request);
 
 $service = $container-&gt;resolve(HealthService::class);
+$controller = $container-&gt;make(HealthController::class);
 $exists = $container-&gt;has(HealthService::class);</code></pre>
 
-            <p>The app registers the current request and router as default singleton services under <code>request</code> and <code>router</code>.</p>
+            <p>The app registers the current request and router as default singleton services under <code>request</code>, <code>Shift\Request</code>, <code>router</code>, and <code>Shift\Routing\Router\Router</code>. It also registers the current <code>Shift\Service\ServiceContainer</code> instance.</p>
         </section>
 
         <section id="cli">

--- a/tests/ApiCoreTest.php
+++ b/tests/ApiCoreTest.php
@@ -85,6 +85,37 @@ final class HeaderMiddleware implements MiddlewareInterface
     }
 }
 
+final class AutowiredGreetingService
+{
+    public function message(): string
+    {
+        return 'autowired';
+    }
+}
+
+final class AutowiredConsumer
+{
+    public function __construct(public readonly AutowiredGreetingService $service)
+    {
+    }
+}
+
+#[RoutePrefix('/autowired')]
+final class AutowiredController extends Controller
+{
+    public function __construct(private readonly AutowiredGreetingService $service)
+    {
+    }
+
+    #[Get('/service')]
+    public function service(): array
+    {
+        return [
+            'message' => $this->service->message(),
+        ];
+    }
+}
+
 function assertSameValue(mixed $expected, mixed $actual, string $message): void
 {
     if ($expected !== $actual) {
@@ -199,6 +230,30 @@ $tests['app dispatches route to controller'] = function (): void {
 
     assertSameValue(200, $emitter->statusCode, 'App should emit successful status.');
     assertSameValue('demo', $payload['data']['routeParams']['argument'] ?? null, 'App should pass route params to controller.');
+};
+
+$tests['app autowires controller constructor dependencies'] = function (): void {
+    $router = new Router();
+    (new AttributeRouteLoader())->load($router, [AutowiredController::class]);
+    $emitter = new CapturingEmitter();
+
+    $app = new App(makeRequest('GET', '/autowired/service'), $router, $emitter);
+    $app->getContainer()->singleton(AutowiredGreetingService::class, AutowiredGreetingService::class);
+    $app->start();
+
+    $payload = json_decode($emitter->content, true);
+
+    assertSameValue(200, $emitter->statusCode, 'Autowired controller should emit successful status.');
+    assertSameValue('autowired', $payload['message'] ?? null, 'Controller dependency should be injected from the container.');
+};
+
+$tests['service container makes classes with typed dependencies'] = function (): void {
+    $container = new ServiceContainer();
+    $container->singleton(AutowiredGreetingService::class, AutowiredGreetingService::class);
+
+    $consumer = $container->make(AutowiredConsumer::class);
+
+    assertSameValue('autowired', $consumer->service->message(), 'Container should autowire typed constructor dependencies.');
 };
 
 $tests['app binds path and query params from attributes'] = function (): void {


### PR DESCRIPTION
## Summary

- Create controllers through the service container instead of direct construction.
- Add `ServiceContainer::make()` for typed constructor dependency autowiring.
- Register the current request, router, and service container as default services by class name.
- Add tests for controller constructor autowiring and container class construction with typed dependencies.
- Update README, REFACTORING.md, and docs/index.html with the new container and controller behavior.

## Validation

- `composer validate --strict --no-check-publish`
- `composer dump-autoload`
- `find Engine application tests -name '*.php' -print0 | xargs -0 -n1 php -l`
- `composer test`
- `php shift.php route:list`
- `php shift.php health`
- HTTP smoke tests:
  - `GET /health -> 200 application/json`
  - `GET /hello -> 404 application/json`

## Release

- Version label: `v0.10.0`