### PR TITLE
Add CLI create generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ php shift.php create:dto Billing:CreateInvoice
 ```
 
 Generator commands normalize module and class names to PHP class conventions. Missing suffixes are added for controllers, services, middleware, and DTOs.
+Generator templates live in `src/Console/Generator/stubs`.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,26 @@ Run the example module command:
 php shift.php health
 ```
 
+Generate module scaffolding:
+
+```sh
+php shift.php create:module Billing
+```
+
+Generate module-owned classes:
+
+```sh
+php shift.php create:controller --module=Billing InvoiceController
+php shift.php create:controller Billing:InvoiceController
+php shift.php create:model Billing:Invoice
+php shift.php create:service Billing:Invoice
+php shift.php create:command Billing:SyncInvoices
+php shift.php create:middleware Billing:Audit
+php shift.php create:dto Billing:CreateInvoice
+```
+
+Generator commands normalize module and class names to PHP class conventions. Missing suffixes are added for controllers, services, middleware, and DTOs.
+
 ## Modules
 
 ShiftPHP supports a modular monolith structure under `application/modules`.
@@ -275,6 +295,8 @@ application/modules/Health/
 ├── Services/
 └── Commands/
 ```
+
+Generated models, middleware, and DTOs live under `Models/`, `Middleware/`, and `Dto/` inside the target module.
 
 A module registers itself through `Module.php`:
 

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -26,6 +26,7 @@ ShiftPHP is moving toward an API-only modular monolith. View templates, compiled
 - [x] Module configuration loading.
 - [x] Module lifecycle hooks, for example `boot()` after service registration.
 - [x] Framework source moved to `src/` for package split preparation.
+- [x] CLI create generators for modules and module-owned classes.
 - [x] Removal of view storage and example page assets from runtime.
 - [x] Removal of legacy `application/controllers` and `application/routes.php`.
 - [x] Domain-oriented framework namespaces:

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -26,7 +26,7 @@ ShiftPHP is moving toward an API-only modular monolith. View templates, compiled
 - [x] Module configuration loading.
 - [x] Module lifecycle hooks, for example `boot()` after service registration.
 - [x] Framework source moved to `src/` for package split preparation.
-- [x] CLI create generators for modules and module-owned classes.
+- [x] CLI create generators for modules and module-owned classes with file-based stubs.
 - [x] Removal of view storage and example page assets from runtime.
 - [x] Removal of legacy `application/controllers` and `application/routes.php`.
 - [x] Domain-oriented framework namespaces:

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "autoload": {
     "psr-4": {
       "Shift\\": "src",
+      "Console\\Commands\\": "src/Console/Commands",
       "Modules\\": "application/modules"
     }
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -405,6 +405,7 @@ php shift.php create:middleware Billing:Audit
 php shift.php create:dto Billing:CreateInvoice</code></pre>
 
             <p>Controller, service, middleware, and DTO generators add the expected class suffix when it is missing. Commands accept either <code>--module=Billing Name</code> or <code>Billing:Name</code>.</p>
+            <p>Generator templates live in <code>src/Console/Generator/stubs</code>.</p>
 
             <p>Commands implement <code>Shift\Console\CommandInterface</code>.</p>
         </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,8 @@ $app-&gt;start();</code></pre>
 |-- Services/
 `-- Commands/</code></pre>
 
+            <p>Generator commands can also create <code>Models/</code>, <code>Middleware/</code>, and <code>Dto/</code> directories when those artifacts are added.</p>
+
             <p>Every module boundary implements <code>Shift\Modules\ModuleInterface</code>. Most modules can extend <code>Shift\Modules\AbstractModule</code> and override only the methods they need.</p>
 
             <pre><code>namespace Modules\Health;
@@ -386,10 +388,23 @@ $exists = $container-&gt;has(HealthService::class);</code></pre>
 
         <section id="cli">
             <h2>CLI</h2>
-            <p>The CLI entry point is <code>shift.php</code>. Built-in commands live under <code>Shift\Console\Commands</code>, and module commands are loaded from module command mappings.</p>
+            <p>The CLI entry point is <code>shift.php</code>. Built-in commands live under <code>Console\Commands</code>, and module commands are loaded from module command mappings.</p>
 
             <pre><code>php shift.php route:list
 php shift.php health</code></pre>
+
+            <p>Create commands scaffold modules and module-owned classes:</p>
+
+            <pre><code>php shift.php create:module Billing
+php shift.php create:controller --module=Billing InvoiceController
+php shift.php create:controller Billing:InvoiceController
+php shift.php create:model Billing:Invoice
+php shift.php create:service Billing:Invoice
+php shift.php create:command Billing:SyncInvoices
+php shift.php create:middleware Billing:Audit
+php shift.php create:dto Billing:CreateInvoice</code></pre>
+
+            <p>Controller, service, middleware, and DTO generators add the expected class suffix when it is missing. Commands accept either <code>--module=Billing Name</code> or <code>Billing:Name</code>.</p>
 
             <p>Commands implement <code>Shift\Console\CommandInterface</code>.</p>
         </section>

--- a/src/Console/Commands/CreateCommand.php
+++ b/src/Console/Commands/CreateCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateCommand implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName);
+        $path = $this->modulePath($module) . '/Commands/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class, NameFormatter::commandName($class)));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:command --module={name} {CommandName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module CLI command.';
+    }
+
+    private function stub(string $module, string $class, string $command): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Commands;
+
+use Shift\\Console\\Cli;
+use Shift\\Console\\CommandInterface;
+
+class {$class} implements CommandInterface
+{
+    public function execute(mixed ...\$args): void
+    {
+        (new Cli())->success('Command executed.');
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php {$command}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Module command.';
+    }
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateCommand.php
+++ b/src/Console/Commands/CreateCommand.php
@@ -22,7 +22,11 @@ class CreateCommand implements CommandInterface
         $class = NameFormatter::className($rawName);
         $path = $this->modulePath($module) . '/Commands/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class, NameFormatter::commandName($class)));
+        $this->writeAndReport($path, $this->renderStub('command', [
+            'module' => $module,
+            'class' => $class,
+            'command' => NameFormatter::commandName($class),
+        ]));
     }
 
     public function getHelp(): string
@@ -35,34 +39,4 @@ class CreateCommand implements CommandInterface
         return 'Create a module CLI command.';
     }
 
-    private function stub(string $module, string $class, string $command): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Commands;
-
-use Shift\\Console\\Cli;
-use Shift\\Console\\CommandInterface;
-
-class {$class} implements CommandInterface
-{
-    public function execute(mixed ...\$args): void
-    {
-        (new Cli())->success('Command executed.');
-    }
-
-    public function getHelp(): string
-    {
-        return 'Usage: php shift.php {$command}';
-    }
-
-    public function getDescription(): string
-    {
-        return 'Module command.';
-    }
-}
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateController.php
+++ b/src/Console/Commands/CreateController.php
@@ -22,7 +22,10 @@ class CreateController implements CommandInterface
         $class = NameFormatter::className($rawName, 'Controller');
         $path = $this->modulePath($module) . '/Controllers/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class));
+        $this->writeAndReport($path, $this->renderStub('controller', [
+            'module' => $module,
+            'class' => $class,
+        ]));
     }
 
     public function getHelp(): string
@@ -35,26 +38,4 @@ class CreateController implements CommandInterface
         return 'Create a module controller.';
     }
 
-    private function stub(string $module, string $class): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Controllers;
-
-use Shift\\Controller;
-use Shift\\Response\\JsonResponse;
-
-class {$class} extends Controller
-{
-    public function index(): JsonResponse
-    {
-        return \$this->json([
-            'status' => 'ok',
-        ]);
-    }
-}
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateController.php
+++ b/src/Console/Commands/CreateController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateController implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName, 'Controller');
+        $path = $this->modulePath($module) . '/Controllers/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:controller --module={name} {ControllerName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module controller.';
+    }
+
+    private function stub(string $module, string $class): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Controllers;
+
+use Shift\\Controller;
+use Shift\\Response\\JsonResponse;
+
+class {$class} extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return \$this->json([
+            'status' => 'ok',
+        ]);
+    }
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateDto.php
+++ b/src/Console/Commands/CreateDto.php
@@ -22,7 +22,10 @@ class CreateDto implements CommandInterface
         $class = NameFormatter::className($rawName, 'Dto');
         $path = $this->modulePath($module) . '/Dto/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class));
+        $this->writeAndReport($path, $this->renderStub('dto', [
+            'module' => $module,
+            'class' => $class,
+        ]));
     }
 
     public function getHelp(): string
@@ -35,28 +38,4 @@ class CreateDto implements CommandInterface
         return 'Create a module request DTO.';
     }
 
-    private function stub(string $module, string $class): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Dto;
-
-use Shift\\Validation\\RequestDto;
-
-class {$class} extends RequestDto
-{
-    public function __construct()
-    {
-    }
-
-    public static function rules(): array
-    {
-        return [
-        ];
-    }
-}
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateDto.php
+++ b/src/Console/Commands/CreateDto.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateDto implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName, 'Dto');
+        $path = $this->modulePath($module) . '/Dto/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:dto --module={name} {DtoName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module request DTO.';
+    }
+
+    private function stub(string $module, string $class): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Dto;
+
+use Shift\\Validation\\RequestDto;
+
+class {$class} extends RequestDto
+{
+    public function __construct()
+    {
+    }
+
+    public static function rules(): array
+    {
+        return [
+        ];
+    }
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateMiddleware.php
+++ b/src/Console/Commands/CreateMiddleware.php
@@ -22,7 +22,10 @@ class CreateMiddleware implements CommandInterface
         $class = NameFormatter::className($rawName, 'Middleware');
         $path = $this->modulePath($module) . '/Middleware/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class));
+        $this->writeAndReport($path, $this->renderStub('middleware', [
+            'module' => $module,
+            'class' => $class,
+        ]));
     }
 
     public function getHelp(): string
@@ -35,25 +38,4 @@ class CreateMiddleware implements CommandInterface
         return 'Create a module middleware.';
     }
 
-    private function stub(string $module, string $class): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Middleware;
-
-use Shift\\Middleware\\MiddlewareInterface;
-use Shift\\Request;
-use Shift\\Response\\Response;
-
-class {$class} implements MiddlewareInterface
-{
-    public function handle(Request \$request, callable \$next): Response
-    {
-        return \$next(\$request);
-    }
-}
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateMiddleware.php
+++ b/src/Console/Commands/CreateMiddleware.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateMiddleware implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName, 'Middleware');
+        $path = $this->modulePath($module) . '/Middleware/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:middleware --module={name} {MiddlewareName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module middleware.';
+    }
+
+    private function stub(string $module, string $class): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Middleware;
+
+use Shift\\Middleware\\MiddlewareInterface;
+use Shift\\Request;
+use Shift\\Response\\Response;
+
+class {$class} implements MiddlewareInterface
+{
+    public function handle(Request \$request, callable \$next): Response
+    {
+        return \$next(\$request);
+    }
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateModel.php
+++ b/src/Console/Commands/CreateModel.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateModel implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName);
+        $path = $this->modulePath($module) . '/Models/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:model --module={name} {ModelName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module model.';
+    }
+
+    private function stub(string $module, string $class): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Models;
+
+class {$class}
+{
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateModel.php
+++ b/src/Console/Commands/CreateModel.php
@@ -22,7 +22,10 @@ class CreateModel implements CommandInterface
         $class = NameFormatter::className($rawName);
         $path = $this->modulePath($module) . '/Models/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class));
+        $this->writeAndReport($path, $this->renderStub('model', [
+            'module' => $module,
+            'class' => $class,
+        ]));
     }
 
     public function getHelp(): string
@@ -35,17 +38,4 @@ class CreateModel implements CommandInterface
         return 'Create a module model.';
     }
 
-    private function stub(string $module, string $class): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Models;
-
-class {$class}
-{
-}
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateModule.php
+++ b/src/Console/Commands/CreateModule.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateModule implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        $rawName = $args[0] ?? null;
+
+        if (!is_string($rawName) || $rawName === '') {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $module = NameFormatter::moduleName($rawName);
+        $slug = NameFormatter::slug($rawName);
+        $path = $this->modulePath($module);
+
+        foreach (['Commands', 'Controllers', 'Services'] as $directory) {
+            $this->files->ensureDirectory($path . '/' . $directory);
+        }
+
+        $this->writeAndReport($path . '/Module.php', $this->moduleStub($module, $slug));
+        $this->writeAndReport($path . '/config.php', $this->configStub($slug));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:module {name}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a new Shift module.';
+    }
+
+    private function moduleStub(string $module, string $slug): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module};
+
+use Shift\\Modules\\AbstractModule;
+use Shift\\Routing\\AttributeRouteLoader;
+use Shift\\Routing\\Router\\Router;
+use Shift\\Service\\ServiceContainer;
+
+class Module extends AbstractModule
+{
+    public function getName(): string
+    {
+        return '{$slug}';
+    }
+
+    public function registerServices(ServiceContainer \$container): void
+    {
+    }
+
+    public function registerRoutes(Router \$router): void
+    {
+        (new AttributeRouteLoader())->load(\$router, [
+        ]);
+    }
+
+    public function getCommandMappings(): array
+    {
+        return [
+            [
+                'dir' => __DIR__ . '/Commands/',
+                'namespace' => 'Modules\\\\{$module}\\\\Commands\\\\',
+            ],
+        ];
+    }
+}
+
+PHP;
+    }
+
+    private function configStub(string $slug): string
+    {
+        return <<<PHP
+<?php
+
+return [
+    'enabled' => true,
+    'module' => '{$slug}',
+];
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateModule.php
+++ b/src/Console/Commands/CreateModule.php
@@ -27,8 +27,13 @@ class CreateModule implements CommandInterface
             $this->files->ensureDirectory($path . '/' . $directory);
         }
 
-        $this->writeAndReport($path . '/Module.php', $this->moduleStub($module, $slug));
-        $this->writeAndReport($path . '/config.php', $this->configStub($slug));
+        $this->writeAndReport($path . '/Module.php', $this->renderStub('module', [
+            'module' => $module,
+            'slug' => $slug,
+        ]));
+        $this->writeAndReport($path . '/config.php', $this->renderStub('config', [
+            'slug' => $slug,
+        ]));
     }
 
     public function getHelp(): string
@@ -41,59 +46,4 @@ class CreateModule implements CommandInterface
         return 'Create a new Shift module.';
     }
 
-    private function moduleStub(string $module, string $slug): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module};
-
-use Shift\\Modules\\AbstractModule;
-use Shift\\Routing\\AttributeRouteLoader;
-use Shift\\Routing\\Router\\Router;
-use Shift\\Service\\ServiceContainer;
-
-class Module extends AbstractModule
-{
-    public function getName(): string
-    {
-        return '{$slug}';
-    }
-
-    public function registerServices(ServiceContainer \$container): void
-    {
-    }
-
-    public function registerRoutes(Router \$router): void
-    {
-        (new AttributeRouteLoader())->load(\$router, [
-        ]);
-    }
-
-    public function getCommandMappings(): array
-    {
-        return [
-            [
-                'dir' => __DIR__ . '/Commands/',
-                'namespace' => 'Modules\\\\{$module}\\\\Commands\\\\',
-            ],
-        ];
-    }
-}
-
-PHP;
-    }
-
-    private function configStub(string $slug): string
-    {
-        return <<<PHP
-<?php
-
-return [
-    'enabled' => true,
-    'module' => '{$slug}',
-];
-
-PHP;
-    }
 }

--- a/src/Console/Commands/CreateService.php
+++ b/src/Console/Commands/CreateService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\CommandInterface;
+use Shift\Console\Generator\GeneratesFiles;
+use Shift\Console\Generator\NameFormatter;
+
+class CreateService implements CommandInterface
+{
+    use GeneratesFiles;
+
+    public function execute(mixed ...$args): void
+    {
+        try {
+            [$module, $rawName] = $this->moduleAndClassFromArgs($args);
+        } catch (\InvalidArgumentException) {
+            $this->cli->error($this->getHelp());
+            return;
+        }
+
+        $class = NameFormatter::className($rawName, 'Service');
+        $path = $this->modulePath($module) . '/Services/' . $class . '.php';
+
+        $this->writeAndReport($path, $this->stub($module, $class));
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php create:service --module={name} {ServiceName}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a module service.';
+    }
+
+    private function stub(string $module, string $class): string
+    {
+        return <<<PHP
+<?php
+
+namespace Modules\\{$module}\\Services;
+
+class {$class}
+{
+}
+
+PHP;
+    }
+}

--- a/src/Console/Commands/CreateService.php
+++ b/src/Console/Commands/CreateService.php
@@ -22,7 +22,10 @@ class CreateService implements CommandInterface
         $class = NameFormatter::className($rawName, 'Service');
         $path = $this->modulePath($module) . '/Services/' . $class . '.php';
 
-        $this->writeAndReport($path, $this->stub($module, $class));
+        $this->writeAndReport($path, $this->renderStub('service', [
+            'module' => $module,
+            'class' => $class,
+        ]));
     }
 
     public function getHelp(): string
@@ -35,17 +38,4 @@ class CreateService implements CommandInterface
         return 'Create a module service.';
     }
 
-    private function stub(string $module, string $class): string
-    {
-        return <<<PHP
-<?php
-
-namespace Modules\\{$module}\\Services;
-
-class {$class}
-{
-}
-
-PHP;
-    }
 }

--- a/src/Console/Generator/FileGenerator.php
+++ b/src/Console/Generator/FileGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Shift\Console\Generator;
+
+final class FileGenerator
+{
+    /** @var list<string> */
+    private array $created = [];
+
+    /** @var list<string> */
+    private array $skipped = [];
+
+    public function ensureDirectory(string $path): void
+    {
+        if (is_dir($path)) {
+            return;
+        }
+
+        mkdir($path, 0775, true);
+        $this->created[] = $path;
+    }
+
+    public function writeFile(string $path, string $content): void
+    {
+        $directory = dirname($path);
+        $this->ensureDirectory($directory);
+
+        if (file_exists($path)) {
+            $this->skipped[] = $path;
+            return;
+        }
+
+        file_put_contents($path, $content);
+        $this->created[] = $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function created(): array
+    {
+        return $this->created;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function skipped(): array
+    {
+        return $this->skipped;
+    }
+}

--- a/src/Console/Generator/GeneratesFiles.php
+++ b/src/Console/Generator/GeneratesFiles.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Shift\Console\Generator;
+
+use Shift\Console\Cli;
+
+trait GeneratesFiles
+{
+    protected FileGenerator $files;
+
+    protected Cli $cli;
+
+    public function __construct(
+        protected readonly string $modulesPath = APP_PATH . '/modules'
+    ) {
+        $this->files = new FileGenerator();
+        $this->cli = new Cli();
+    }
+
+    /**
+     * @param list<mixed> $args
+     * @return array{0: string, 1: string}
+     */
+    protected function moduleAndClassFromArgs(array $args): array
+    {
+        $module = null;
+        $name = null;
+
+        foreach ($args as $arg) {
+            if (!is_string($arg) || $arg === '') {
+                continue;
+            }
+
+            if (str_starts_with($arg, '--module=')) {
+                $module = substr($arg, 9);
+                continue;
+            }
+
+            if ($module === null && str_contains($arg, ':')) {
+                [$module, $name] = explode(':', $arg, 2);
+                continue;
+            }
+
+            $name ??= $arg;
+        }
+
+        if ($module === null || $module === '' || $name === null || $name === '') {
+            throw new \InvalidArgumentException('Module and class name are required.');
+        }
+
+        return [
+            NameFormatter::moduleName($module),
+            $name,
+        ];
+    }
+
+    protected function modulePath(string $module): string
+    {
+        return rtrim($this->modulesPath, '/') . '/' . $module;
+    }
+
+    protected function writeAndReport(string $path, string $content): void
+    {
+        $beforeSkipped = count($this->files->skipped());
+        $this->files->writeFile($path, $content);
+
+        if (count($this->files->skipped()) > $beforeSkipped) {
+            $this->cli->warning('Skipped existing file: ' . $path);
+            return;
+        }
+
+        $this->cli->success('Created: ' . $path);
+    }
+}

--- a/src/Console/Generator/GeneratesFiles.php
+++ b/src/Console/Generator/GeneratesFiles.php
@@ -8,12 +8,15 @@ trait GeneratesFiles
 {
     protected FileGenerator $files;
 
+    protected StubRenderer $stubs;
+
     protected Cli $cli;
 
     public function __construct(
         protected readonly string $modulesPath = APP_PATH . '/modules'
     ) {
         $this->files = new FileGenerator();
+        $this->stubs = new StubRenderer();
         $this->cli = new Cli();
     }
 
@@ -70,5 +73,13 @@ trait GeneratesFiles
         }
 
         $this->cli->success('Created: ' . $path);
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    protected function renderStub(string $stub, array $variables): string
+    {
+        return $this->stubs->render($stub, $variables);
     }
 }

--- a/src/Console/Generator/NameFormatter.php
+++ b/src/Console/Generator/NameFormatter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Shift\Console\Generator;
+
+final class NameFormatter
+{
+    public static function className(string $name, string $suffix = ''): string
+    {
+        $name = str_replace('\\', '/', $name);
+        $name = basename($name);
+        $name = self::studly($name);
+
+        if ($suffix !== '' && !str_ends_with($name, $suffix)) {
+            return $name . $suffix;
+        }
+
+        return $name;
+    }
+
+    public static function moduleName(string $name): string
+    {
+        return self::studly($name);
+    }
+
+    public static function commandName(string $className): string
+    {
+        $parts = preg_split('/(?=[A-Z])/', $className, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $parts = array_map(static fn (string $part): string => strtolower($part), $parts);
+
+        return implode(':', $parts);
+    }
+
+    public static function slug(string $name): string
+    {
+        $parts = preg_split('/[^a-zA-Z0-9]+/', $name, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $parts = array_map(static fn (string $part): string => strtolower($part), $parts);
+
+        return implode('-', $parts);
+    }
+
+    private static function studly(string $name): string
+    {
+        $parts = preg_split('/[^a-zA-Z0-9]+/', $name, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $parts = array_map(static fn (string $part): string => ucfirst($part), $parts);
+
+        return implode('', $parts);
+    }
+}

--- a/src/Console/Generator/StubRenderer.php
+++ b/src/Console/Generator/StubRenderer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Shift\Console\Generator;
+
+final class StubRenderer
+{
+    public function __construct(
+        private readonly string $stubPath = __DIR__ . '/stubs'
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    public function render(string $stub, array $variables): string
+    {
+        $path = rtrim($this->stubPath, '/') . '/' . $stub . '.stub';
+
+        if (!is_file($path)) {
+            throw new \RuntimeException("Stub {$stub} not found.");
+        }
+
+        $content = file_get_contents($path);
+
+        if (!is_string($content)) {
+            throw new \RuntimeException("Stub {$stub} cannot be read.");
+        }
+
+        foreach ($variables as $name => $value) {
+            $content = str_replace('{{ ' . $name . ' }}', $value, $content);
+        }
+
+        return $content;
+    }
+}

--- a/src/Console/Generator/stubs/command.stub
+++ b/src/Console/Generator/stubs/command.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\{{ module }}\Commands;
+
+use Shift\Console\Cli;
+use Shift\Console\CommandInterface;
+
+class {{ class }} implements CommandInterface
+{
+    public function execute(mixed ...$args): void
+    {
+        (new Cli())->success('Command executed.');
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: php shift.php {{ command }}';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Module command.';
+    }
+}

--- a/src/Console/Generator/stubs/config.stub
+++ b/src/Console/Generator/stubs/config.stub
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'enabled' => true,
+    'module' => '{{ slug }}',
+];

--- a/src/Console/Generator/stubs/controller.stub
+++ b/src/Console/Generator/stubs/controller.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\{{ module }}\Controllers;
+
+use Shift\Controller;
+use Shift\Response\JsonResponse;
+
+class {{ class }} extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return $this->json([
+            'status' => 'ok',
+        ]);
+    }
+}

--- a/src/Console/Generator/stubs/dto.stub
+++ b/src/Console/Generator/stubs/dto.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\{{ module }}\Dto;
+
+use Shift\Validation\RequestDto;
+
+class {{ class }} extends RequestDto
+{
+    public function __construct()
+    {
+    }
+
+    public static function rules(): array
+    {
+        return [
+        ];
+    }
+}

--- a/src/Console/Generator/stubs/middleware.stub
+++ b/src/Console/Generator/stubs/middleware.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\{{ module }}\Middleware;
+
+use Shift\Middleware\MiddlewareInterface;
+use Shift\Request;
+use Shift\Response\Response;
+
+class {{ class }} implements MiddlewareInterface
+{
+    public function handle(Request $request, callable $next): Response
+    {
+        return $next($request);
+    }
+}

--- a/src/Console/Generator/stubs/model.stub
+++ b/src/Console/Generator/stubs/model.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Modules\{{ module }}\Models;
+
+class {{ class }}
+{
+}

--- a/src/Console/Generator/stubs/module.stub
+++ b/src/Console/Generator/stubs/module.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\{{ module }};
+
+use Shift\Modules\AbstractModule;
+use Shift\Routing\AttributeRouteLoader;
+use Shift\Routing\Router\Router;
+use Shift\Service\ServiceContainer;
+
+class Module extends AbstractModule
+{
+    public function getName(): string
+    {
+        return '{{ slug }}';
+    }
+
+    public function registerServices(ServiceContainer $container): void
+    {
+    }
+
+    public function registerRoutes(Router $router): void
+    {
+        (new AttributeRouteLoader())->load($router, [
+        ]);
+    }
+
+    public function getCommandMappings(): array
+    {
+        return [
+            [
+                'dir' => __DIR__ . '/Commands/',
+                'namespace' => 'Modules\\{{ module }}\\Commands\\',
+            ],
+        ];
+    }
+}

--- a/src/Console/Generator/stubs/service.stub
+++ b/src/Console/Generator/stubs/service.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Modules\{{ module }}\Services;
+
+class {{ class }}
+{
+}

--- a/tests/Feature/ConsoleCreateTest.php
+++ b/tests/Feature/ConsoleCreateTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Console\Commands\CreateCommand;
+use Console\Commands\CreateController;
+use Console\Commands\CreateDto;
+use Console\Commands\CreateMiddleware;
+use Console\Commands\CreateModel;
+use Console\Commands\CreateModule;
+use Console\Commands\CreateService;
+
+return [
+    'create:module scaffolds a module boundary' => function (): void {
+        $modulesPath = makeTempModulesPath();
+
+        try {
+            (new CreateModule($modulesPath))->execute('billing');
+
+            assertFileExists($modulesPath . '/Billing/Module.php', 'Module.php should be created.');
+            assertFileExists($modulesPath . '/Billing/config.php', 'config.php should be created.');
+            assertDirectoryExists($modulesPath . '/Billing/Commands', 'Commands directory should be created.');
+            assertDirectoryExists($modulesPath . '/Billing/Controllers', 'Controllers directory should be created.');
+            assertDirectoryExists($modulesPath . '/Billing/Services', 'Services directory should be created.');
+
+            $module = file_get_contents($modulesPath . '/Billing/Module.php');
+            $config = file_get_contents($modulesPath . '/Billing/config.php');
+            assertStringContains('namespace Modules\\Billing;', $module, 'Module namespace should match module name.');
+            assertStringContains("'namespace' => 'Modules\\\\Billing\\\\Commands\\\\'", $module, 'Module should expose command mappings.');
+            assertStringContains("'module' => 'billing'", $config, 'Module config should use the module slug.');
+        } finally {
+            removeDirectory(dirname($modulesPath));
+        }
+    },
+    'create:controller supports module option and inline module syntax' => function (): void {
+        $modulesPath = makeTempModulesPath();
+
+        try {
+            (new CreateController($modulesPath))->execute('--module=billing', 'invoice');
+            (new CreateController($modulesPath))->execute('billing:PaymentController');
+
+            assertFileExists($modulesPath . '/Billing/Controllers/InvoiceController.php', 'Controller suffix should be added.');
+            assertFileExists($modulesPath . '/Billing/Controllers/PaymentController.php', 'Inline module syntax should be supported.');
+
+            $controller = file_get_contents($modulesPath . '/Billing/Controllers/InvoiceController.php');
+            assertStringContains('namespace Modules\\Billing\\Controllers;', $controller, 'Controller namespace should match module.');
+            assertStringContains('class InvoiceController extends Controller', $controller, 'Controller class should extend base controller.');
+        } finally {
+            removeDirectory(dirname($modulesPath));
+        }
+    },
+    'create artifact commands write module-owned classes' => function (): void {
+        $modulesPath = makeTempModulesPath();
+
+        try {
+            (new CreateModel($modulesPath))->execute('billing:Invoice');
+            (new CreateService($modulesPath))->execute('billing:Invoice');
+            (new CreateCommand($modulesPath))->execute('billing:SyncInvoices');
+            (new CreateMiddleware($modulesPath))->execute('billing:Audit');
+            (new CreateDto($modulesPath))->execute('billing:CreateInvoice');
+
+            assertFileExists($modulesPath . '/Billing/Models/Invoice.php', 'Model should be created.');
+            assertFileExists($modulesPath . '/Billing/Services/InvoiceService.php', 'Service suffix should be added.');
+            assertFileExists($modulesPath . '/Billing/Commands/SyncInvoices.php', 'Command should be created.');
+            assertFileExists($modulesPath . '/Billing/Middleware/AuditMiddleware.php', 'Middleware suffix should be added.');
+            assertFileExists($modulesPath . '/Billing/Dto/CreateInvoiceDto.php', 'DTO suffix should be added.');
+
+            $command = file_get_contents($modulesPath . '/Billing/Commands/SyncInvoices.php');
+            assertStringContains('return \'Usage: php shift.php sync:invoices\';', $command, 'Generated command help should use CLI command syntax.');
+        } finally {
+            removeDirectory(dirname($modulesPath));
+        }
+    },
+];

--- a/tests/Support/TestSupport.php
+++ b/tests/Support/TestSupport.php
@@ -45,3 +45,57 @@ function makeRequest(string $method, string $uri, string $body = '', array $quer
         $body
     );
 }
+
+function assertFileExists(string $path, string $message): void
+{
+    if (!is_file($path)) {
+        throw new RuntimeException($message . "\nMissing file: {$path}");
+    }
+}
+
+function assertDirectoryExists(string $path, string $message): void
+{
+    if (!is_dir($path)) {
+        throw new RuntimeException($message . "\nMissing directory: {$path}");
+    }
+}
+
+function assertStringContains(string $needle, string|false $haystack, string $message): void
+{
+    if (!is_string($haystack) || !str_contains($haystack, $needle)) {
+        throw new RuntimeException($message . "\nNeedle: {$needle}\nHaystack: " . var_export($haystack, true));
+    }
+}
+
+function makeTempModulesPath(): string
+{
+    $root = sys_get_temp_dir() . '/shift-create-' . bin2hex(random_bytes(6));
+    $modules = $root . '/modules';
+
+    mkdir($modules, 0775, true);
+
+    return $modules;
+}
+
+function removeDirectory(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isDir()) {
+            rmdir($file->getPathname());
+            continue;
+        }
+
+        unlink($file->getPathname());
+    }
+
+    rmdir($path);
+}


### PR DESCRIPTION
## Summary
- add create:module scaffolding for module directories, Module.php, and config.php
- add module-owned generators for controllers, models, services, commands, middleware, and DTOs
- support both --module=Name ClassName and Module:ClassName syntax for artifact generators
- extract generator templates into file-based stubs under src/Console/Generator/stubs
- add zero-dependency .env loading during bootstrap
- add native PDO database config, lazy connection service, query result helpers, and transaction wrapper
- document create commands, generator stubs, .env configuration, and database usage
- cover generator, environment, and database behavior with feature tests

## Tests
- composer validate --no-check-publish
- composer dump-autoload
- find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- php shift.php route:list
- php shift.php health