### PR TITLE
Add model query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,60 @@ class UserService
 
 Available helpers are `query($sql, $parameters)`, `execute($sql, $parameters)`, `pdo()`, and `transaction($callback)`. Query results expose `all()`, `first()`, `value()`, `affectedRows()`, and the raw `PDOStatement`.
 
+### Query Builder and Models
+
+Use the table query builder for simple fluent queries:
+
+```php
+$users = $db->table('users')
+    ->select('id', 'email')
+    ->where('active', true)
+    ->orderBy('id', 'desc')
+    ->limit(10)
+    ->get();
+```
+
+Models extend `Shift\Database\Model`. Public properties represent database columns:
+
+```php
+use Shift\Database\Attributes\Cast;
+use Shift\Database\Attributes\Guarded;
+use Shift\Database\Attributes\PrimaryKey;
+use Shift\Database\Model;
+
+class User extends Model
+{
+    protected string $table = 'users';
+
+    #[PrimaryKey]
+    #[Cast('int')]
+    public ?int $id = null;
+
+    public string $email = '';
+
+    #[Guarded]
+    public string $role = 'user';
+
+    #[Cast('array')]
+    public array $meta = [];
+
+    #[Cast('datetime')]
+    public ?DateTimeImmutable $created_at = null;
+}
+```
+
+Model queries return hydrated model instances:
+
+```php
+$user = User::query($db)->where('email', 'dev@example.com')->first();
+$user = User::find(1, $db);
+$user = User::create(['email' => 'dev@example.com'], $db);
+$user->role = 'admin';
+$user->save($db);
+```
+
+`#[Guarded]` fields are ignored during mass assignment through `create()` and query `update()`, but can be set explicitly on a model instance before `save()`. Supported casts include `int`, `float`, `bool`, `string`, `array`, `date`, `datetime`, and class names. Class casts use `fromArray()` when available.
+
 ## Service Container
 
 The container can resolve registered services and build classes with typed constructor dependencies:

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -29,6 +29,7 @@ ShiftPHP is moving toward an API-only modular monolith. View templates, compiled
 - [x] CLI create generators for modules and module-owned classes with file-based stubs.
 - [x] `.env` loading for application configuration.
 - [x] Native PDO database configuration, lazy connection, and basic query API.
+- [x] Fluent query builder and attribute-driven database models.
 - [x] Removal of view storage and example page assets from runtime.
 - [x] Removal of legacy `application/controllers` and `application/routes.php`.
 - [x] Domain-oriented framework namespaces:

--- a/docs/index.html
+++ b/docs/index.html
@@ -423,6 +423,50 @@ class UserService
 }</code></pre>
 
             <p>Use <code>query()</code> for prepared queries, <code>execute()</code> for write statements, <code>pdo()</code> for raw PDO access, and <code>transaction()</code> for transactional work.</p>
+
+            <h3>Query Builder</h3>
+            <pre><code>$users = $db-&gt;table('users')
+    -&gt;select('id', 'email')
+    -&gt;where('active', true)
+    -&gt;orderBy('id', 'desc')
+    -&gt;limit(10)
+    -&gt;get();</code></pre>
+
+            <h3>Models</h3>
+            <p>Models extend <code>Shift\Database\Model</code>. Public properties are database columns, and model attributes describe primary keys, guarded fields, and casts.</p>
+
+            <pre><code>use Shift\Database\Attributes\Cast;
+use Shift\Database\Attributes\Guarded;
+use Shift\Database\Attributes\PrimaryKey;
+use Shift\Database\Model;
+
+class User extends Model
+{
+    protected string $table = 'users';
+
+    #[PrimaryKey]
+    #[Cast('int')]
+    public ?int $id = null;
+
+    public string $email = '';
+
+    #[Guarded]
+    public string $role = 'user';
+
+    #[Cast('array')]
+    public array $meta = [];
+
+    #[Cast('datetime')]
+    public ?DateTimeImmutable $created_at = null;
+}</code></pre>
+
+            <pre><code>$user = User::query($db)-&gt;where('email', 'dev@example.com')-&gt;first();
+$user = User::find(1, $db);
+$user = User::create(['email' =&gt; 'dev@example.com'], $db);
+$user-&gt;role = 'admin';
+$user-&gt;save($db);</code></pre>
+
+            <p><code>#[Guarded]</code> fields are ignored during mass assignment through <code>create()</code> and query <code>update()</code>, but can be set explicitly before <code>save()</code>. Supported casts include <code>int</code>, <code>float</code>, <code>bool</code>, <code>string</code>, <code>array</code>, <code>date</code>, <code>datetime</code>, and class names. Class casts use <code>fromArray()</code> when available.</p>
         </section>
 
         <section id="cli">

--- a/src/Console/Commands/CreateModel.php
+++ b/src/Console/Commands/CreateModel.php
@@ -25,6 +25,7 @@ class CreateModel implements CommandInterface
         $this->writeAndReport($path, $this->renderStub('model', [
             'module' => $module,
             'class' => $class,
+            'table' => NameFormatter::tableName($class),
         ]));
     }
 

--- a/src/Console/Generator/NameFormatter.php
+++ b/src/Console/Generator/NameFormatter.php
@@ -30,6 +30,13 @@ final class NameFormatter
         return implode(':', $parts);
     }
 
+    public static function tableName(string $className): string
+    {
+        $snake = strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $className));
+
+        return str_ends_with($snake, 's') ? $snake : $snake . 's';
+    }
+
     public static function slug(string $name): string
     {
         $parts = preg_split('/[^a-zA-Z0-9]+/', $name, -1, PREG_SPLIT_NO_EMPTY) ?: [];

--- a/src/Console/Generator/stubs/model.stub
+++ b/src/Console/Generator/stubs/model.stub
@@ -2,6 +2,9 @@
 
 namespace Modules\{{ module }}\Models;
 
-class {{ class }}
+use Shift\Database\Model;
+
+class {{ class }} extends Model
 {
+    protected string $table = '{{ table }}';
 }

--- a/src/Database/Attributes/Cast.php
+++ b/src/Database/Attributes/Cast.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Shift\Database\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Cast
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly ?string $format = null
+    ) {
+    }
+}

--- a/src/Database/Attributes/Guarded.php
+++ b/src/Database/Attributes/Guarded.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Shift\Database\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Guarded
+{
+}

--- a/src/Database/Attributes/PrimaryKey.php
+++ b/src/Database/Attributes/PrimaryKey.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Shift\Database\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class PrimaryKey
+{
+}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -50,6 +50,11 @@ final class Database
         }
     }
 
+    public function table(string $table): QueryBuilder
+    {
+        return new QueryBuilder($this, $table);
+    }
+
     public function execute(string $sql, array $parameters = []): int
     {
         return $this->query($sql, $parameters)->affectedRows();
@@ -69,6 +74,11 @@ final class Database
             $pdo->rollBack();
             throw $exception;
         }
+    }
+
+    public function lastInsertId(?string $name = null): string
+    {
+        return $this->pdo()->lastInsertId($name);
     }
 
     private function options(): array

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Shift\Database;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+use ReflectionClass;
+use ReflectionProperty;
+use Shift\Database\Attributes\Cast;
+use Shift\Database\Attributes\Guarded;
+use Shift\Database\Attributes\PrimaryKey;
+
+abstract class Model
+{
+    protected string $table = '';
+
+    private static ?Database $database = null;
+
+    public static function useDatabase(Database $database): void
+    {
+        self::$database = $database;
+    }
+
+    public static function query(?Database $database = null): ModelQueryBuilder
+    {
+        return new ModelQueryBuilder(static::class, $database ?? self::database());
+    }
+
+    public static function find(mixed $id, ?Database $database = null): ?static
+    {
+        return static::query($database)->find($id);
+    }
+
+    public static function create(array $attributes, ?Database $database = null): static
+    {
+        return static::query($database)->create($attributes);
+    }
+
+    public static function hydrate(array $attributes): static
+    {
+        $model = new static();
+        $model->fill($attributes, includeGuarded: true);
+
+        return $model;
+    }
+
+    public function fill(array $attributes, bool $includeGuarded = false): static
+    {
+        foreach ($attributes as $column => $value) {
+            if (!$includeGuarded && $this->isGuarded($column)) {
+                continue;
+            }
+
+            if (!$this->hasColumn($column)) {
+                continue;
+            }
+
+            $this->{$column} = $this->castFromDatabase($column, $value);
+        }
+
+        return $this;
+    }
+
+    public function forceFill(array $attributes): static
+    {
+        return $this->fill($attributes, includeGuarded: true);
+    }
+
+    public function save(?Database $database = null): bool
+    {
+        $database ??= self::database();
+        $primaryKey = static::primaryKey();
+        $attributes = $this->storableAttributes();
+        $id = $this->{$primaryKey} ?? null;
+
+        if ($id !== null) {
+            unset($attributes[$primaryKey]);
+
+            if ($attributes === []) {
+                return true;
+            }
+
+            return $database->table(static::table())
+                ->where($primaryKey, $id)
+                ->update($attributes) > 0;
+        }
+
+        if (($attributes[$primaryKey] ?? null) === null) {
+            unset($attributes[$primaryKey]);
+        }
+
+        $id = $database->table(static::table())->insertGetId($attributes);
+
+        if ($this->hasColumn($primaryKey)) {
+            $this->{$primaryKey} = $this->castFromDatabase($primaryKey, $id);
+        }
+
+        return true;
+    }
+
+    public function delete(?Database $database = null): int
+    {
+        $primaryKey = static::primaryKey();
+        $id = $this->{$primaryKey} ?? null;
+
+        if ($id === null) {
+            return 0;
+        }
+
+        return static::query($database)->where($primaryKey, $id)->delete();
+    }
+
+    public function toArray(): array
+    {
+        $values = [];
+
+        foreach (static::columns() as $column => $property) {
+            if (!$property->isInitialized($this)) {
+                continue;
+            }
+
+            $values[$column] = $this->{$column};
+        }
+
+        return $values;
+    }
+
+    public static function table(): string
+    {
+        $defaults = (new ReflectionClass(static::class))->getDefaultProperties();
+        $table = $defaults['table'] ?? '';
+
+        if (is_string($table) && $table !== '') {
+            return $table;
+        }
+
+        return static::defaultTableName();
+    }
+
+    public static function primaryKey(): string
+    {
+        foreach (static::columns() as $column => $property) {
+            if ($property->getAttributes(PrimaryKey::class) !== []) {
+                return $column;
+            }
+        }
+
+        return array_key_exists('id', static::columns()) ? 'id' : 'id';
+    }
+
+    public function storableAttributes(): array
+    {
+        $values = [];
+
+        foreach (static::columns() as $column => $property) {
+            if (!$property->isInitialized($this)) {
+                continue;
+            }
+
+            $values[$column] = $this->castForDatabase($column, $this->{$column});
+        }
+
+        return $values;
+    }
+
+    public function storableInput(array $attributes, bool $includeGuarded = false): array
+    {
+        $values = [];
+
+        foreach ($attributes as $column => $value) {
+            if (!$includeGuarded && $this->isGuarded($column)) {
+                continue;
+            }
+
+            if (!$this->hasColumn($column)) {
+                continue;
+            }
+
+            $values[$column] = $this->castForDatabase($column, $value);
+        }
+
+        return $values;
+    }
+
+    public static function guardedColumns(): array
+    {
+        $guarded = [];
+
+        foreach (static::columns() as $column => $property) {
+            if ($property->getAttributes(Guarded::class) !== []) {
+                $guarded[] = $column;
+            }
+        }
+
+        return $guarded;
+    }
+
+    /**
+     * @return array<string, ReflectionProperty>
+     */
+    public static function columns(): array
+    {
+        $reflection = new ReflectionClass(static::class);
+        $columns = [];
+
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $columns[$property->getName()] = $property;
+        }
+
+        return $columns;
+    }
+
+    private static function database(): Database
+    {
+        if (!self::$database instanceof Database) {
+            throw new DatabaseException('No database configured for model queries.');
+        }
+
+        return self::$database;
+    }
+
+    private function hasColumn(string $column): bool
+    {
+        return array_key_exists($column, static::columns());
+    }
+
+    private function isGuarded(string $column): bool
+    {
+        return in_array($column, static::guardedColumns(), true);
+    }
+
+    private function castFromDatabase(string $column, mixed $value): mixed
+    {
+        $cast = $this->castForColumn($column);
+
+        if ($cast === null || $value === null) {
+            return $value;
+        }
+
+        return match (strtolower($cast->type)) {
+            'int', 'integer' => (int) $value,
+            'float', 'double' => (float) $value,
+            'bool', 'boolean' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            'string' => (string) $value,
+            'array' => is_array($value) ? $value : (json_decode((string) $value, true) ?: []),
+            'datetime', 'date' => $value instanceof DateTimeInterface
+                ? DateTimeImmutable::createFromInterface($value)
+                : new DateTimeImmutable((string) $value),
+            default => $this->castClassFromDatabase($cast->type, $value),
+        };
+    }
+
+    private function castForDatabase(string $column, mixed $value): mixed
+    {
+        $cast = $this->castForColumn($column);
+
+        if ($cast === null || $value === null) {
+            return $value;
+        }
+
+        return match (strtolower($cast->type)) {
+            'int', 'integer' => (int) $value,
+            'float', 'double' => (float) $value,
+            'bool', 'boolean' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            'string' => (string) $value,
+            'array' => json_encode($value, JSON_THROW_ON_ERROR),
+            'datetime' => $value instanceof DateTimeInterface
+                ? $value->format($cast->format ?? DateTimeInterface::ATOM)
+                : $value,
+            'date' => $value instanceof DateTimeInterface
+                ? $value->format($cast->format ?? 'Y-m-d')
+                : $value,
+            default => $this->castClassForDatabase($value),
+        };
+    }
+
+    private function castForColumn(string $column): ?Cast
+    {
+        $property = static::columns()[$column] ?? null;
+
+        if (!$property instanceof ReflectionProperty) {
+            return null;
+        }
+
+        $attributes = $property->getAttributes(Cast::class);
+
+        if ($attributes === []) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    private function castClassFromDatabase(string $class, mixed $value): mixed
+    {
+        if (!class_exists($class)) {
+            return $value;
+        }
+
+        if (is_a($value, $class)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            $value = json_last_error() === JSON_ERROR_NONE ? $decoded : $value;
+        }
+
+        if (method_exists($class, 'fromArray') && is_array($value)) {
+            return $class::fromArray($value);
+        }
+
+        return new $class($value);
+    }
+
+    private function castClassForDatabase(mixed $value): mixed
+    {
+        if ($value instanceof JsonSerializable) {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        }
+
+        if (is_object($value) && method_exists($value, 'toArray')) {
+            return json_encode($value->toArray(), JSON_THROW_ON_ERROR);
+        }
+
+        return $value;
+    }
+
+    private static function defaultTableName(): string
+    {
+        $shortName = (new ReflectionClass(static::class))->getShortName();
+        $snake = strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $shortName));
+
+        return str_ends_with($snake, 's') ? $snake : $snake . 's';
+    }
+}

--- a/src/Database/ModelQueryBuilder.php
+++ b/src/Database/ModelQueryBuilder.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Shift\Database;
+
+/**
+ * @template TModel of Model
+ */
+final class ModelQueryBuilder
+{
+    private QueryBuilder $query;
+
+    /**
+     * @param class-string<TModel> $modelClass
+     */
+    public function __construct(
+        private readonly string $modelClass,
+        private readonly Database $database
+    ) {
+        $this->query = $database->table($modelClass::table());
+    }
+
+    public function select(string ...$columns): self
+    {
+        $this->query->select(...$columns);
+
+        return $this;
+    }
+
+    public function where(string $column, mixed $operatorOrValue, mixed $value = null): self
+    {
+        func_num_args() === 2
+            ? $this->query->where($column, $operatorOrValue)
+            : $this->query->where($column, $operatorOrValue, $value);
+
+        return $this;
+    }
+
+    public function orWhere(string $column, mixed $operatorOrValue, mixed $value = null): self
+    {
+        func_num_args() === 2
+            ? $this->query->orWhere($column, $operatorOrValue)
+            : $this->query->orWhere($column, $operatorOrValue, $value);
+
+        return $this;
+    }
+
+    public function orderBy(string $column, string $direction = 'asc'): self
+    {
+        $this->query->orderBy($column, $direction);
+
+        return $this;
+    }
+
+    public function limit(int $limit, ?int $offset = null): self
+    {
+        $this->query->limit($limit, $offset);
+
+        return $this;
+    }
+
+    /**
+     * @return list<TModel>
+     */
+    public function get(): array
+    {
+        $modelClass = $this->modelClass;
+
+        return array_map(
+            fn (array $row): Model => $modelClass::hydrate($row),
+            $this->query->get()
+        );
+    }
+
+    /**
+     * @return TModel|null
+     */
+    public function first(): ?Model
+    {
+        $modelClass = $this->modelClass;
+        $row = $this->query->first();
+
+        return $row === null ? null : $modelClass::hydrate($row);
+    }
+
+    /**
+     * @return TModel|null
+     */
+    public function find(mixed $id): ?Model
+    {
+        $modelClass = $this->modelClass;
+
+        return $this->where($modelClass::primaryKey(), $id)->first();
+    }
+
+    /**
+     * @return TModel
+     */
+    public function create(array $attributes): Model
+    {
+        $modelClass = $this->modelClass;
+        $model = new $modelClass();
+        $model->fill($attributes);
+        $values = $model->storableAttributes();
+        $primaryKey = $modelClass::primaryKey();
+
+        if (($values[$primaryKey] ?? null) === null) {
+            unset($values[$primaryKey]);
+        }
+
+        $id = $this->database->table($modelClass::table())->insertGetId($values);
+
+        if (array_key_exists($primaryKey, $modelClass::columns())) {
+            $model->{$primaryKey} = $model::hydrate([$primaryKey => $id])->{$primaryKey};
+        }
+
+        return $model;
+    }
+
+    public function update(array $attributes): int
+    {
+        $modelClass = $this->modelClass;
+        $model = new $modelClass();
+        $values = $model->storableInput($attributes);
+
+        if ($values === []) {
+            return 0;
+        }
+
+        return $this->query->update($values);
+    }
+
+    public function delete(): int
+    {
+        return $this->query->delete();
+    }
+
+    public function toSql(): string
+    {
+        return $this->query->toSql();
+    }
+}

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Shift\Database;
+
+final class QueryBuilder
+{
+    /** @var list<string> */
+    private array $columns = ['*'];
+
+    /** @var list<array{boolean: string, column: string, operator: string, value: mixed}> */
+    private array $wheres = [];
+
+    /** @var list<array{column: string, direction: string}> */
+    private array $orders = [];
+
+    private ?int $limit = null;
+
+    private ?int $offset = null;
+
+    public function __construct(
+        private readonly Database $database,
+        private readonly string $table
+    ) {
+    }
+
+    public function select(string ...$columns): self
+    {
+        $this->columns = $columns === [] ? ['*'] : $columns;
+
+        return $this;
+    }
+
+    public function where(string $column, mixed $operatorOrValue, mixed $value = null): self
+    {
+        if (func_num_args() === 2) {
+            $operator = '=';
+            $value = $operatorOrValue;
+        } else {
+            $operator = strtolower((string) $operatorOrValue);
+        }
+
+        $this->wheres[] = [
+            'boolean' => 'and',
+            'column' => $column,
+            'operator' => $this->normalizeOperator($operator),
+            'value' => $value,
+        ];
+
+        return $this;
+    }
+
+    public function orWhere(string $column, mixed $operatorOrValue, mixed $value = null): self
+    {
+        if (func_num_args() === 2) {
+            $operator = '=';
+            $value = $operatorOrValue;
+        } else {
+            $operator = strtolower((string) $operatorOrValue);
+        }
+
+        $this->wheres[] = [
+            'boolean' => 'or',
+            'column' => $column,
+            'operator' => $this->normalizeOperator($operator),
+            'value' => $value,
+        ];
+
+        return $this;
+    }
+
+    public function orderBy(string $column, string $direction = 'asc'): self
+    {
+        $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
+        $this->orders[] = [
+            'column' => $column,
+            'direction' => $direction,
+        ];
+
+        return $this;
+    }
+
+    public function limit(int $limit, ?int $offset = null): self
+    {
+        $this->limit = max(0, $limit);
+        $this->offset = $offset === null ? null : max(0, $offset);
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        return $this->database->query($this->toSql(), $this->bindings())->all();
+    }
+
+    public function first(): ?array
+    {
+        $this->limit(1);
+
+        return $this->database->query($this->toSql(), $this->bindings())->first();
+    }
+
+    public function value(string|int $column = 0): mixed
+    {
+        $this->limit(1);
+
+        return $this->database->query($this->toSql(), $this->bindings())->value($column);
+    }
+
+    public function insert(array $values): int
+    {
+        if ($values === []) {
+            throw new DatabaseException('Insert values cannot be empty.');
+        }
+
+        $columns = array_keys($values);
+        $placeholders = array_fill(0, count($columns), '?');
+        $sql = sprintf(
+            'insert into %s (%s) values (%s)',
+            $this->identifier($this->table),
+            implode(', ', array_map(fn (string $column): string => $this->identifier($column), $columns)),
+            implode(', ', $placeholders)
+        );
+
+        return $this->database->execute($sql, array_values($values));
+    }
+
+    public function insertGetId(array $values): string
+    {
+        $this->insert($values);
+
+        return $this->database->lastInsertId();
+    }
+
+    public function update(array $values): int
+    {
+        if ($values === []) {
+            return 0;
+        }
+
+        $assignments = array_map(
+            fn (string $column): string => $this->identifier($column) . ' = ?',
+            array_keys($values)
+        );
+
+        $sql = sprintf(
+            'update %s set %s%s',
+            $this->identifier($this->table),
+            implode(', ', $assignments),
+            $this->whereSql()
+        );
+
+        return $this->database->execute($sql, array_merge(array_values($values), $this->bindings()));
+    }
+
+    public function delete(): int
+    {
+        $sql = sprintf(
+            'delete from %s%s',
+            $this->identifier($this->table),
+            $this->whereSql()
+        );
+
+        return $this->database->execute($sql, $this->bindings());
+    }
+
+    public function toSql(): string
+    {
+        $sql = sprintf(
+            'select %s from %s%s%s',
+            implode(', ', array_map(fn (string $column): string => $this->identifier($column), $this->columns)),
+            $this->identifier($this->table),
+            $this->whereSql(),
+            $this->orderSql()
+        );
+
+        if ($this->limit !== null) {
+            $sql .= ' limit ' . $this->limit;
+        }
+
+        if ($this->offset !== null) {
+            $sql .= ' offset ' . $this->offset;
+        }
+
+        return $sql;
+    }
+
+    private function whereSql(): string
+    {
+        if ($this->wheres === []) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($this->wheres as $index => $where) {
+            $prefix = $index === 0 ? ' where ' : ' ' . $where['boolean'] . ' ';
+            $parts[] = $prefix . $this->identifier($where['column']) . ' ' . $where['operator'] . ' ?';
+        }
+
+        return implode('', $parts);
+    }
+
+    private function orderSql(): string
+    {
+        if ($this->orders === []) {
+            return '';
+        }
+
+        $parts = array_map(
+            fn (array $order): string => $this->identifier($order['column']) . ' ' . $order['direction'],
+            $this->orders
+        );
+
+        return ' order by ' . implode(', ', $parts);
+    }
+
+    private function bindings(): array
+    {
+        return array_map(
+            static fn (array $where): mixed => $where['value'],
+            $this->wheres
+        );
+    }
+
+    private function identifier(string $identifier): string
+    {
+        if ($identifier === '*') {
+            return $identifier;
+        }
+
+        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/', $identifier)) {
+            throw new DatabaseException("Invalid database identifier '{$identifier}'.");
+        }
+
+        return $identifier;
+    }
+
+    private function normalizeOperator(string $operator): string
+    {
+        $allowed = ['=', '!=', '<>', '>', '>=', '<', '<=', 'like', 'not like'];
+
+        if (!in_array($operator, $allowed, true)) {
+            throw new DatabaseException("Invalid query operator '{$operator}'.");
+        }
+
+        return $operator;
+    }
+}

--- a/tests/Feature/ConsoleCreateTest.php
+++ b/tests/Feature/ConsoleCreateTest.php
@@ -63,7 +63,10 @@ return [
             assertFileExists($modulesPath . '/Billing/Middleware/AuditMiddleware.php', 'Middleware suffix should be added.');
             assertFileExists($modulesPath . '/Billing/Dto/CreateInvoiceDto.php', 'DTO suffix should be added.');
 
+            $model = file_get_contents($modulesPath . '/Billing/Models/Invoice.php');
             $command = file_get_contents($modulesPath . '/Billing/Commands/SyncInvoices.php');
+            assertStringContains('class Invoice extends Model', $model, 'Generated models should extend the base model.');
+            assertStringContains("protected string \$table = 'invoices';", $model, 'Generated models should define a table name.');
             assertStringContains('return \'Usage: php shift.php sync:invoices\';', $command, 'Generated command help should use CLI command syntax.');
         } finally {
             removeDirectory(dirname($modulesPath));

--- a/tests/Feature/ModelQueryBuilderTest.php
+++ b/tests/Feature/ModelQueryBuilderTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use Shift\Database\Attributes\Cast;
+use Shift\Database\Attributes\Guarded;
+use Shift\Database\Attributes\PrimaryKey;
+use Shift\Database\Database;
+use Shift\Database\DatabaseConfig;
+use Shift\Database\Model;
+
+final class TestProfileCast
+{
+    public function __construct(public readonly array $data)
+    {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data);
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}
+
+final class TestUserRecord extends Model
+{
+    protected string $table = 'test_users';
+
+    #[PrimaryKey]
+    #[Cast('int')]
+    public ?int $id = null;
+
+    public string $email = '';
+
+    #[Guarded]
+    public string $role = 'user';
+
+    #[Cast('array')]
+    public array $meta = [];
+
+    #[Cast('datetime')]
+    public ?DateTimeImmutable $created_at = null;
+
+    #[Cast(TestProfileCast::class)]
+    public ?TestProfileCast $profile = null;
+}
+
+return [
+    'query builder selects rows with fluent clauses' => function (): void {
+        $db = makeModelDatabase();
+        seedModelRows($db);
+
+        $rows = $db->table('test_users')
+            ->select('id', 'email')
+            ->where('role', 'admin')
+            ->orderBy('id', 'desc')
+            ->limit(1)
+            ->get();
+
+        assertSameValue(1, count($rows), 'Query builder should respect where and limit clauses.');
+        assertSameValue('second@example.com', $rows[0]['email'] ?? null, 'Query builder should order selected rows.');
+    },
+    'model query hydrates casts from database rows' => function (): void {
+        $db = makeModelDatabase();
+        seedModelRows($db);
+
+        $user = TestUserRecord::query($db)->where('email', 'first@example.com')->first();
+
+        assertSameValue(true, $user instanceof TestUserRecord, 'Model query should hydrate model instances.');
+        assertSameValue(1, $user->id, 'Primary key should be cast to int.');
+        assertSameValue(['tags' => ['api', 'db']], $user->meta, 'Array cast should decode JSON.');
+        assertSameValue(true, $user->created_at instanceof DateTimeImmutable, 'Datetime cast should return DateTimeImmutable.');
+        assertSameValue(true, $user->profile instanceof TestProfileCast, 'Class cast should hydrate value objects.');
+        assertSameValue('Ada', $user->profile->data['name'] ?? null, 'Class cast should receive decoded data.');
+    },
+    'model create skips guarded input and explicit save can persist guarded fields' => function (): void {
+        $db = makeModelDatabase();
+
+        $user = TestUserRecord::create([
+            'email' => 'guarded@example.com',
+            'role' => 'admin',
+            'meta' => ['source' => 'test'],
+            'created_at' => new DateTimeImmutable('2026-06-17 10:00:00'),
+            'profile' => new TestProfileCast(['name' => 'Grace']),
+        ], $db);
+
+        $stored = TestUserRecord::find($user->id, $db);
+        assertSameValue('user', $stored->role, 'Guarded fields should not be mass assigned.');
+
+        $updated = TestUserRecord::query($db)
+            ->where('id', $user->id)
+            ->update(['role' => 'admin']);
+
+        assertSameValue(0, $updated, 'Guarded fields should not be updated through mass assignment.');
+
+        $stored->role = 'admin';
+        $stored->save($db);
+        $reloaded = TestUserRecord::find($user->id, $db);
+
+        assertSameValue('admin', $reloaded->role, 'Guarded fields can be persisted when set explicitly on the model.');
+    },
+    'model query supports find and delete' => function (): void {
+        $db = makeModelDatabase();
+        seedModelRows($db);
+
+        $user = TestUserRecord::find(1, $db);
+        $deleted = $user->delete($db);
+        $missing = TestUserRecord::find(1, $db);
+
+        assertSameValue(1, $deleted, 'Model delete should remove the current record.');
+        assertSameValue(null, $missing, 'Deleted models should not be found.');
+    },
+];
+
+function makeModelDatabase(): Database
+{
+    $db = new Database(new DatabaseConfig(
+        driver: 'sqlite',
+        database: ':memory:'
+    ));
+
+    $db->execute(
+        'create table test_users (
+            id integer primary key autoincrement,
+            email text not null,
+            role text not null,
+            meta text,
+            created_at text,
+            profile text
+        )'
+    );
+
+    return $db;
+}
+
+function seedModelRows(Database $db): void
+{
+    $db->table('test_users')->insert([
+        'email' => 'first@example.com',
+        'role' => 'user',
+        'meta' => json_encode(['tags' => ['api', 'db']], JSON_THROW_ON_ERROR),
+        'created_at' => '2026-06-17T10:00:00+00:00',
+        'profile' => json_encode(['name' => 'Ada'], JSON_THROW_ON_ERROR),
+    ]);
+
+    $db->table('test_users')->insert([
+        'email' => 'second@example.com',
+        'role' => 'admin',
+        'meta' => json_encode(['tags' => ['ops']], JSON_THROW_ON_ERROR),
+        'created_at' => '2026-06-17T11:00:00+00:00',
+        'profile' => json_encode(['name' => 'Linus'], JSON_THROW_ON_ERROR),
+    ]);
+}


### PR DESCRIPTION
## Summary
- add a fluent table query builder with select, where, ordering, limits, insert, update, and delete
- add attribute-driven database models with PrimaryKey, Guarded, and Cast attributes
- support model find, create, save, delete, hydrated casts, explicit guarded updates, and public column properties
- update create:model stubs to extend the base Model and define table names
- document query builder usage, model conventions, guarded fields, and casts
- cover query builder behavior, model casts, guarded fields, and model persistence with feature tests

## Tests
- composer validate --no-check-publish
- composer dump-autoload
- find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- php shift.php route:list
- php shift.php health