### PR TITLE
Rename CLI entrypoint to shift

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -35,13 +35,15 @@ jobs:
         run: composer dump-autoload
 
       - name: Lint PHP files
-        run: find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
+        run: |
+          php -l shift
+          find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
 
       - name: Run API core tests
         run: composer test
 
       - name: Verify route list command
-        run: php shift.php route:list
+        run: ./shift route:list
 
   version-label:
     name: Version label required

--- a/README.md
+++ b/README.md
@@ -350,31 +350,31 @@ http://127.0.0.1:8000/health
 List registered API routes:
 
 ```sh
-php shift.php route:list
+./shift route:list
 ```
 
 Run the example module command:
 
 ```sh
-php shift.php health
+./shift health
 ```
 
 Generate module scaffolding:
 
 ```sh
-php shift.php create:module Billing
+./shift create:module Billing
 ```
 
 Generate module-owned classes:
 
 ```sh
-php shift.php create:controller --module=Billing InvoiceController
-php shift.php create:controller Billing:InvoiceController
-php shift.php create:model Billing:Invoice
-php shift.php create:service Billing:Invoice
-php shift.php create:command Billing:SyncInvoices
-php shift.php create:middleware Billing:Audit
-php shift.php create:dto Billing:CreateInvoice
+./shift create:controller --module=Billing InvoiceController
+./shift create:controller Billing:InvoiceController
+./shift create:model Billing:Invoice
+./shift create:service Billing:Invoice
+./shift create:command Billing:SyncInvoices
+./shift create:middleware Billing:Audit
+./shift create:dto Billing:CreateInvoice
 ```
 
 Generator commands normalize module and class names to PHP class conventions. Missing suffixes are added for controllers, services, middleware, and DTOs.

--- a/application/modules/Health/Commands/Health.php
+++ b/application/modules/Health/Commands/Health.php
@@ -20,7 +20,7 @@ class Health implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php health';
+        return 'Usage: ./shift health';
     }
 
     public function getDescription(): string

--- a/docs/index.html
+++ b/docs/index.html
@@ -471,21 +471,21 @@ $user-&gt;save($db);</code></pre>
 
         <section id="cli">
             <h2>CLI</h2>
-            <p>The CLI entry point is <code>shift.php</code>. Built-in commands live under <code>Console\Commands</code>, and module commands are loaded from module command mappings.</p>
+            <p>The CLI entry point is <code>shift</code>. Built-in commands live under <code>Console\Commands</code>, and module commands are loaded from module command mappings.</p>
 
-            <pre><code>php shift.php route:list
-php shift.php health</code></pre>
+            <pre><code>./shift route:list
+./shift health</code></pre>
 
             <p>Create commands scaffold modules and module-owned classes:</p>
 
-            <pre><code>php shift.php create:module Billing
-php shift.php create:controller --module=Billing InvoiceController
-php shift.php create:controller Billing:InvoiceController
-php shift.php create:model Billing:Invoice
-php shift.php create:service Billing:Invoice
-php shift.php create:command Billing:SyncInvoices
-php shift.php create:middleware Billing:Audit
-php shift.php create:dto Billing:CreateInvoice</code></pre>
+            <pre><code>./shift create:module Billing
+./shift create:controller --module=Billing InvoiceController
+./shift create:controller Billing:InvoiceController
+./shift create:model Billing:Invoice
+./shift create:service Billing:Invoice
+./shift create:command Billing:SyncInvoices
+./shift create:middleware Billing:Audit
+./shift create:dto Billing:CreateInvoice</code></pre>
 
             <p>Controller, service, middleware, and DTO generators add the expected class suffix when it is missing. Commands accept either <code>--module=Billing Name</code> or <code>Billing:Name</code>.</p>
             <p>Generator templates live in <code>src/Console/Generator/stubs</code>.</p>

--- a/shift
+++ b/shift
@@ -1,10 +1,10 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 use Shift\App;
 use Shift\Console\Shift;
 
-require_once 'bootstrap.php';
+require_once __DIR__ . '/bootstrap.php';
 App::setHelpers();
 $console = new Shift($argv);
 $console->run();

--- a/src/Console/Commands/CreateCommand.php
+++ b/src/Console/Commands/CreateCommand.php
@@ -31,7 +31,7 @@ class CreateCommand implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:command --module={name} {CommandName}';
+        return 'Usage: ./shift create:command --module={name} {CommandName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateController.php
+++ b/src/Console/Commands/CreateController.php
@@ -30,7 +30,7 @@ class CreateController implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:controller --module={name} {ControllerName}';
+        return 'Usage: ./shift create:controller --module={name} {ControllerName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateDto.php
+++ b/src/Console/Commands/CreateDto.php
@@ -30,7 +30,7 @@ class CreateDto implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:dto --module={name} {DtoName}';
+        return 'Usage: ./shift create:dto --module={name} {DtoName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateMiddleware.php
+++ b/src/Console/Commands/CreateMiddleware.php
@@ -30,7 +30,7 @@ class CreateMiddleware implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:middleware --module={name} {MiddlewareName}';
+        return 'Usage: ./shift create:middleware --module={name} {MiddlewareName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateModel.php
+++ b/src/Console/Commands/CreateModel.php
@@ -31,7 +31,7 @@ class CreateModel implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:model --module={name} {ModelName}';
+        return 'Usage: ./shift create:model --module={name} {ModelName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateModule.php
+++ b/src/Console/Commands/CreateModule.php
@@ -38,7 +38,7 @@ class CreateModule implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:module {name}';
+        return 'Usage: ./shift create:module {name}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/CreateService.php
+++ b/src/Console/Commands/CreateService.php
@@ -30,7 +30,7 @@ class CreateService implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php create:service --module={name} {ServiceName}';
+        return 'Usage: ./shift create:service --module={name} {ServiceName}';
     }
 
     public function getDescription(): string

--- a/src/Console/Commands/RouteList.php
+++ b/src/Console/Commands/RouteList.php
@@ -35,7 +35,7 @@ class RouteList implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php route:list';
+        return 'Usage: ./shift route:list';
     }
 
     public function getDescription(): string

--- a/src/Console/Generator/stubs/command.stub
+++ b/src/Console/Generator/stubs/command.stub
@@ -14,7 +14,7 @@ class {{ class }} implements CommandInterface
 
     public function getHelp(): string
     {
-        return 'Usage: php shift.php {{ command }}';
+        return 'Usage: ./shift {{ command }}';
     }
 
     public function getDescription(): string

--- a/tests/Feature/ConsoleCreateTest.php
+++ b/tests/Feature/ConsoleCreateTest.php
@@ -67,7 +67,7 @@ return [
             $command = file_get_contents($modulesPath . '/Billing/Commands/SyncInvoices.php');
             assertStringContains('class Invoice extends Model', $model, 'Generated models should extend the base model.');
             assertStringContains("protected string \$table = 'invoices';", $model, 'Generated models should define a table name.');
-            assertStringContains('return \'Usage: php shift.php sync:invoices\';', $command, 'Generated command help should use CLI command syntax.');
+            assertStringContains('return \'Usage: ./shift sync:invoices\';', $command, 'Generated command help should use CLI command syntax.');
         } finally {
             removeDirectory(dirname($modulesPath));
         }


### PR DESCRIPTION
## Summary
- rename the CLI entrypoint from shift.php to executable shift
- switch the shebang to /usr/bin/env php and load bootstrap.php relative to the entrypoint
- update command help text, generated command stubs, README, developer docs, tests, and CI examples to use ./shift
- lint the extensionless CLI entrypoint in the API workflow

## Tests
- composer validate --no-check-publish
- php -l shift
- find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- ./shift route:list
- ./shift health