### PR TITLE
Add command metadata and request diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ $request->post('name');
 $request->input('name');
 $request->getJson();
 $request->getHeader('Authorization');
+$request->getRequestId();
 $request->routeParam('id');
 ```
 
-Malformed JSON bodies are returned as `400 Bad Request`.
+If the request does not include `X-Request-Id`, ShiftPHP generates one. The same id is emitted on every response as `X-Request-Id` and included in structured exception logs. Malformed JSON bodies are returned as `400 Bad Request`.
 
 ## Validation and DTOs
 
@@ -405,13 +406,37 @@ http://127.0.0.1:8000/health
 
 ## CLI
 
-The CLI discovers framework, application, and module commands through the command registry. Command names are normalized, so `migrate:status`, `migrate-status`, and `migrate_status` resolve to the same command.
+The CLI discovers framework, application, and module commands through the command registry. Command names are declared with `#[Command]` attributes and can include aliases and groups. Command names are normalized, so `migrate:status`, `migrate-status`, and `migrate_status` resolve to the same command.
+
+```php
+use Shift\Console\Attributes\Command;
+use Shift\Console\CommandInterface;
+
+#[Command('billing:sync', aliases: ['sync-billing'], group: 'modules')]
+final class SyncBilling implements CommandInterface
+{
+    public function execute(mixed ...$args): void
+    {
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: ./shift billing:sync';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Sync billing data.';
+    }
+}
+```
 
 Show all commands or command-specific help:
 
 ```sh
 ./shift help
 ./shift help migrate
+./shift help ms
 ```
 
 List registered API routes:
@@ -441,6 +466,7 @@ Inspect framework/runtime information:
 Check local environment and database configuration:
 
 ```sh
+./shift doctor
 ./shift env:check
 ./shift db:check
 ```

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -33,9 +33,12 @@ ShiftPHP is moving toward an API-only modular monolith. View templates, compiled
 - [x] CLI diagnostics for tests, runtime info, environment, database, and modules.
 - [x] CLI help listing and command-specific usage.
 - [x] Centralized CLI command registry shared by the dispatcher and help command.
+- [x] CLI command metadata through attributes, aliases, and grouped help.
+- [x] `shift doctor` project diagnostics.
 - [x] Database migrations with create, migrate, status, and rollback commands.
 - [x] Module discovery cache for production.
 - [x] Structured exception logging with JSON file logger and service container override.
+- [x] Request id lifecycle with generated `X-Request-Id` response headers and log context.
 - [x] Removal of view storage and example page assets from runtime.
 - [x] Removal of legacy `application/controllers` and `application/routes.php`.
 - [x] Domain-oriented framework namespaces:
@@ -161,5 +164,4 @@ Internal errors return a generic `500` message unless `display_errors` is enable
 
 ## Next
 
-- [ ] CLI command aliases and richer command metadata.
-- [ ] Basic package-quality checks, for example static analysis and coding style.
+- [ ] Static analysis and coding style checks.

--- a/application/modules/Health/Commands/Health.php
+++ b/application/modules/Health/Commands/Health.php
@@ -6,6 +6,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Modules\Health\Services\HealthService;
 
+#[\Shift\Console\Attributes\Command('health', group: 'modules')]
 class Health implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/docs/index.html
+++ b/docs/index.html
@@ -275,9 +275,11 @@ $request-&gt;getJson();
 $request-&gt;getHeader('Authorization');
 $request-&gt;getUserAgent();
 $request-&gt;getIpAddress();
+$request-&gt;getRequestId();
 $request-&gt;getRouteParams();
 $request-&gt;routeParam('id');</code></pre>
 
+            <p>If a request does not include <code>X-Request-Id</code>, ShiftPHP generates one. The same id is emitted on every response as <code>X-Request-Id</code> and included in structured exception logs.</p>
             <p><code>getJson()</code> returns an empty array for an empty body. Malformed JSON throws an HTTP error and is returned as <code>400 Bad Request</code>.</p>
         </section>
 
@@ -522,10 +524,33 @@ return new class extends Migration
         <section id="cli">
             <h2>CLI</h2>
             <p>The CLI entry point is <code>shift</code>. Built-in commands live under <code>Console\Commands</code>, and module commands are loaded from module command mappings.</p>
-            <p><code>Shift\Console\CommandRegistry</code> discovers framework, application, and module commands. It normalizes command names, so <code>migrate:status</code>, <code>migrate-status</code>, and <code>migrate_status</code> resolve to the same command.</p>
+            <p><code>Shift\Console\CommandRegistry</code> discovers framework, application, and module commands. Commands can declare their name, aliases, and help group with <code>#[Command]</code>. It normalizes command names, so <code>migrate:status</code>, <code>migrate-status</code>, and <code>migrate_status</code> resolve to the same command.</p>
+
+            <pre><code>use Shift\Console\Attributes\Command;
+use Shift\Console\CommandInterface;
+
+#[Command('billing:sync', aliases: ['sync-billing'], group: 'modules')]
+final class SyncBilling implements CommandInterface
+{
+    public function execute(mixed ...$args): void
+    {
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: ./shift billing:sync';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Sync billing data.';
+    }
+}</code></pre>
 
             <pre><code>./shift help
 ./shift help migrate
+./shift help ms
+./shift doctor
 ./shift route:list
 ./shift test
 ./shift health

--- a/src/App.php
+++ b/src/App.php
@@ -77,7 +77,7 @@ final class App
             $response = JsonResponse::error('Internal Server Error', 500);
         }
 
-        $this->emitter->emit($response);
+        $this->emitter->emit($this->withRequestId($response));
     }
 
     public function middleware(MiddlewareInterface|callable|string $middleware): self
@@ -397,5 +397,14 @@ final class App
             (new ExceptionLogger($this->container->resolve(LoggerInterface::class)))->log($exception, $this->request, $statusCode);
         } catch (Throwable) {
         }
+    }
+
+    private function withRequestId(Response $response): Response
+    {
+        return new Response(
+            $response->getContent(),
+            $response->getStatusCode(),
+            ['X-Request-Id' => $this->request->getRequestId()] + $response->getHeaders()
+        );
     }
 }

--- a/src/Console/Attributes/Command.php
+++ b/src/Console/Attributes/Command.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Shift\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Command
+{
+    /**
+     * @param list<string> $aliases
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly array $aliases = [],
+        public readonly string $group = 'general'
+    ) {
+    }
+}

--- a/src/Console/CommandDefinition.php
+++ b/src/Console/CommandDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Shift\Console;
+
+final class CommandDefinition
+{
+    /**
+     * @param class-string<CommandInterface> $class
+     * @param list<string> $aliases
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $class,
+        public readonly array $aliases = [],
+        public readonly string $group = 'general'
+    ) {
+    }
+
+    public function instantiate(): CommandInterface
+    {
+        return new $this->class();
+    }
+}

--- a/src/Console/CommandRegistry.php
+++ b/src/Console/CommandRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Shift\Console;
 
+use ReflectionClass;
+use Shift\Console\Attributes\Command;
 use Shift\Modules\ModuleLoader;
 
 final class CommandRegistry
@@ -23,7 +25,18 @@ final class CommandRegistry
      */
     public function all(): array
     {
-        $commands = [];
+        return array_map(
+            static fn (CommandDefinition $definition): string => $definition->class,
+            $this->definitions()
+        );
+    }
+
+    /**
+     * @return array<string, CommandDefinition>
+     */
+    public function definitions(): array
+    {
+        $definitions = [];
 
         foreach ($this->mappings() as $mapping) {
             if (!is_dir($mapping['dir'])) {
@@ -37,14 +50,15 @@ final class CommandRegistry
                 $class = $mapping['namespace'] . $className;
 
                 if (class_exists($class) && is_subclass_of($class, CommandInterface::class)) {
-                    $commands[self::nameFromClass($className)] = $class;
+                    $definition = $this->definitionFor($class, $className);
+                    $definitions[$definition->name] = $definition;
                 }
             }
         }
 
-        ksort($commands);
+        ksort($definitions);
 
-        return $commands;
+        return $definitions;
     }
 
     /**
@@ -52,7 +66,20 @@ final class CommandRegistry
      */
     public function find(string $command): ?string
     {
-        return $this->all()[$this->normalize($command)] ?? null;
+        return $this->findDefinition($command)?->class;
+    }
+
+    public function findDefinition(string $command): ?CommandDefinition
+    {
+        $normalized = $this->normalize($command);
+
+        foreach ($this->definitions() as $definition) {
+            if ($definition->name === $normalized || in_array($normalized, $definition->aliases, true)) {
+                return $definition;
+            }
+        }
+
+        return null;
     }
 
     public function normalize(string $command): string
@@ -81,6 +108,41 @@ final class CommandRegistry
         $commandParts = array_map(static fn (string $part): string => strtolower($part), $commandParts);
 
         return implode(':', $commandParts);
+    }
+
+    /**
+     * @param class-string<CommandInterface> $class
+     */
+    private function definitionFor(string $class, string $fallbackClassName): CommandDefinition
+    {
+        $reflection = new ReflectionClass($class);
+        $attributes = $reflection->getAttributes(Command::class);
+
+        if ($attributes !== []) {
+            /** @var Command $attribute */
+            $attribute = $attributes[0]->newInstance();
+
+            return new CommandDefinition(
+                $this->normalize($attribute->name),
+                $class,
+                $this->normalizeList($attribute->aliases),
+                $attribute->group
+            );
+        }
+
+        return new CommandDefinition(self::nameFromClass($fallbackClassName), $class);
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<string>
+     */
+    private function normalizeList(array $values): array
+    {
+        return array_values(array_filter(array_map(
+            fn (string $value): string => $this->normalize($value),
+            $values
+        )));
     }
 
     /**

--- a/src/Console/Commands/About.php
+++ b/src/Console/Commands/About.php
@@ -6,6 +6,7 @@ use Shift\Config\Env;
 use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 
+#[\Shift\Console\Attributes\Command('about', group: 'diagnostics')]
 class About implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/CacheClear.php
+++ b/src/Console/Commands/CacheClear.php
@@ -6,6 +6,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Shift\Modules\ModuleLoader;
 
+#[\Shift\Console\Attributes\Command('cache:clear', aliases: ['cc'], group: 'cache')]
 class CacheClear implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/CacheModules.php
+++ b/src/Console/Commands/CacheModules.php
@@ -6,6 +6,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Shift\Modules\ModuleLoader;
 
+#[\Shift\Console\Attributes\Command('cache:modules', aliases: ['cm'], group: 'cache')]
 class CacheModules implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/CacheStatus.php
+++ b/src/Console/Commands/CacheStatus.php
@@ -6,6 +6,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Shift\Modules\ModuleLoader;
 
+#[\Shift\Console\Attributes\Command('cache:status', aliases: ['cs'], group: 'cache')]
 class CacheStatus implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/CreateCommand.php
+++ b/src/Console/Commands/CreateCommand.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:command', group: 'make')]
 class CreateCommand implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateController.php
+++ b/src/Console/Commands/CreateController.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:controller', group: 'make')]
 class CreateController implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateDto.php
+++ b/src/Console/Commands/CreateDto.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:dto', group: 'make')]
 class CreateDto implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateMiddleware.php
+++ b/src/Console/Commands/CreateMiddleware.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:middleware', group: 'make')]
 class CreateMiddleware implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateMigration.php
+++ b/src/Console/Commands/CreateMigration.php
@@ -8,6 +8,7 @@ use Shift\Console\Generator\FileGenerator;
 use Shift\Console\Generator\NameFormatter;
 use Shift\Console\Generator\StubRenderer;
 
+#[\Shift\Console\Attributes\Command('create:migration', group: 'database')]
 class CreateMigration implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/CreateModel.php
+++ b/src/Console/Commands/CreateModel.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:model', group: 'make')]
 class CreateModel implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateModule.php
+++ b/src/Console/Commands/CreateModule.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:module', group: 'make')]
 class CreateModule implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/CreateService.php
+++ b/src/Console/Commands/CreateService.php
@@ -6,6 +6,7 @@ use Shift\Console\CommandInterface;
 use Shift\Console\Generator\GeneratesFiles;
 use Shift\Console\Generator\NameFormatter;
 
+#[\Shift\Console\Attributes\Command('create:service', group: 'make')]
 class CreateService implements CommandInterface
 {
     use GeneratesFiles;

--- a/src/Console/Commands/DbCheck.php
+++ b/src/Console/Commands/DbCheck.php
@@ -9,6 +9,7 @@ use Shift\Database\DatabaseConfig;
 use Shift\Database\DatabaseException;
 use Throwable;
 
+#[\Shift\Console\Attributes\Command('db:check', group: 'diagnostics')]
 class DbCheck implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/Doctor.php
+++ b/src/Console/Commands/Doctor.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Console\Commands;
+
+use Shift\Console\Cli;
+use Shift\Console\CommandInterface;
+use Shift\Database\DatabaseConfig;
+use Shift\Modules\ModuleLoader;
+use Throwable;
+
+#[\Shift\Console\Attributes\Command('doctor', aliases: ['check'], group: 'diagnostics')]
+class Doctor implements CommandInterface
+{
+    public function execute(mixed ...$args): void
+    {
+        $cli = new Cli();
+        $checks = [
+            $this->phpVersion(),
+            $this->extensions(),
+            $this->composerConfig(),
+            $this->phpLint(),
+            $this->testSuite(),
+            $this->environment(),
+            $this->databaseConfig(),
+            $this->moduleCache(),
+        ];
+
+        $failed = array_values(array_filter($checks, static fn (array $check): bool => $check[1] === 'fail'));
+        $cli->table(['Check', 'Status', 'Details'], $checks);
+
+        if ($failed === []) {
+            $cli->success('Doctor checks passed.');
+            return;
+        }
+
+        $cli->error('Doctor found ' . count($failed) . ' failing check(s).');
+        exit(1);
+    }
+
+    public function getHelp(): string
+    {
+        return 'Usage: ./shift doctor';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Run project diagnostics.';
+    }
+
+    private function phpVersion(): array
+    {
+        return [
+            'PHP version',
+            version_compare(PHP_VERSION, '8.3.0', '>=') ? 'ok' : 'fail',
+            PHP_VERSION,
+        ];
+    }
+
+    private function extensions(): array
+    {
+        $missing = array_values(array_filter(
+            ['json', 'pdo'],
+            static fn (string $extension): bool => !extension_loaded($extension)
+        ));
+
+        return [
+            'PHP extensions',
+            $missing === [] ? 'ok' : 'fail',
+            $missing === [] ? 'json, pdo' : 'Missing: ' . implode(', ', $missing),
+        ];
+    }
+
+    private function composerConfig(): array
+    {
+        $path = APP_ROOT . '/composer.json';
+
+        if (!is_file($path)) {
+            return ['Composer config', 'fail', 'composer.json not found'];
+        }
+
+        json_decode((string) file_get_contents($path), true);
+
+        return [
+            'Composer config',
+            json_last_error() === JSON_ERROR_NONE ? 'ok' : 'fail',
+            json_last_error() === JSON_ERROR_NONE ? 'composer.json valid JSON' : json_last_error_msg(),
+        ];
+    }
+
+    private function phpLint(): array
+    {
+        $files = array_merge(
+            $this->phpFiles(APP_ROOT . '/src'),
+            $this->phpFiles(APP_ROOT . '/application'),
+            $this->phpFiles(APP_ROOT . '/tests'),
+            [APP_ROOT . '/shift']
+        );
+
+        foreach ($files as $file) {
+            if (!is_file($file)) {
+                continue;
+            }
+
+            exec(escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($file) . ' 2>&1', $output, $exitCode);
+
+            if ($exitCode !== 0) {
+                return ['PHP lint', 'fail', basename($file) . ': ' . trim(implode(' ', $output))];
+            }
+        }
+
+        return ['PHP lint', 'ok', count($files) . ' file(s) checked'];
+    }
+
+    private function testSuite(): array
+    {
+        exec('composer test 2>&1', $output, $exitCode);
+
+        return [
+            'Test suite',
+            $exitCode === 0 ? 'ok' : 'fail',
+            $exitCode === 0 ? 'composer test passed' : trim(implode(' ', array_slice($output, -3))),
+        ];
+    }
+
+    private function environment(): array
+    {
+        return [
+            'Environment',
+            is_file(APP_ROOT . '/.env') ? 'ok' : 'warn',
+            is_file(APP_ROOT . '/.env') ? '.env present' : '.env not found',
+        ];
+    }
+
+    private function databaseConfig(): array
+    {
+        try {
+            $config = DatabaseConfig::fromEnv();
+        } catch (Throwable $exception) {
+            return ['Database config', 'fail', $exception->getMessage()];
+        }
+
+        return [
+            'Database config',
+            $config->driver !== '' && $config->database !== '' ? 'ok' : 'warn',
+            $config->driver . ':' . ($config->database !== '' ? $config->database : '(empty)'),
+        ];
+    }
+
+    private function moduleCache(): array
+    {
+        $loader = new ModuleLoader();
+
+        return [
+            'Module cache',
+            'ok',
+            $loader->isCached() ? 'cached' : 'empty',
+        ];
+    }
+
+    private function phpFiles(string $path): array
+    {
+        if (!is_dir($path)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/src/Console/Commands/EnvCheck.php
+++ b/src/Console/Commands/EnvCheck.php
@@ -6,6 +6,7 @@ use Shift\Config\Env;
 use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 
+#[\Shift\Console\Attributes\Command('env:check', group: 'diagnostics')]
 class EnvCheck implements CommandInterface
 {
     /** @var list<string> */

--- a/src/Console/Commands/Help.php
+++ b/src/Console/Commands/Help.php
@@ -12,6 +12,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Shift\Console\CommandRegistry;
 
+#[\Shift\Console\Attributes\Command('help', aliases: ['h'], group: 'core')]
 class Help implements CommandInterface
 {
     public function __construct(private readonly CommandRegistry $registry = new CommandRegistry())
@@ -33,15 +34,21 @@ class Help implements CommandInterface
     private function displayHelpForCommand(string $command): void
     {
         $cli = new Cli();
-        $class = $this->registry->find($command);
+        $definition = $this->registry->findDefinition($command);
 
-        if ($class === null) {
+        if ($definition === null) {
             $cli->error('Command not found: ' . $command);
             return;
         }
 
-        $instance = new $class();
-        $cli->info(CommandRegistry::nameFromClass($class));
+        $instance = $definition->instantiate();
+        $cli->info($definition->name);
+        $cli->debug('Group: ' . $definition->group);
+
+        if ($definition->aliases !== []) {
+            $cli->debug('Aliases: ' . implode(', ', $definition->aliases));
+        }
+
         $cli->debug($instance->getDescription());
         $cli->debug($instance->getHelp());
     }
@@ -49,19 +56,25 @@ class Help implements CommandInterface
     private function displayFullHelp(): void
     {
         $cli = new Cli();
-        $rows = [];
+        $groups = [];
 
-        foreach ($this->registry->all() as $command => $class) {
-            $instance = new $class();
-            $rows[] = [
-                $command,
+        foreach ($this->registry->definitions() as $definition) {
+            $instance = $definition->instantiate();
+            $groups[$definition->group][] = [
+                $definition->name,
+                $definition->aliases === [] ? '' : implode(', ', $definition->aliases),
                 $instance->getDescription(),
             ];
         }
 
-        usort($rows, static fn (array $left, array $right): int => strcmp($left[0], $right[0]));
+        ksort($groups);
 
-        $cli->table(['Command', 'Description'], $rows);
+        foreach ($groups as $group => $rows) {
+            usort($rows, static fn (array $left, array $right): int => strcmp($left[0], $right[0]));
+
+            $cli->info(ucfirst($group));
+            $cli->table(['Command', 'Aliases', 'Description'], $rows);
+        }
     }
 
     public function getHelp(): string

--- a/src/Console/Commands/Migrate.php
+++ b/src/Console/Commands/Migrate.php
@@ -8,6 +8,7 @@ use Shift\Database\Database;
 use Shift\Database\DatabaseConfig;
 use Shift\Database\Migrations\MigrationRunner;
 
+#[\Shift\Console\Attributes\Command('migrate', aliases: ['m'], group: 'database')]
 class Migrate implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/MigrateRollback.php
+++ b/src/Console/Commands/MigrateRollback.php
@@ -8,6 +8,7 @@ use Shift\Database\Database;
 use Shift\Database\DatabaseConfig;
 use Shift\Database\Migrations\MigrationRunner;
 
+#[\Shift\Console\Attributes\Command('migrate:rollback', aliases: ['rollback'], group: 'database')]
 class MigrateRollback implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/MigrateStatus.php
+++ b/src/Console/Commands/MigrateStatus.php
@@ -8,6 +8,7 @@ use Shift\Database\Database;
 use Shift\Database\DatabaseConfig;
 use Shift\Database\Migrations\MigrationRunner;
 
+#[\Shift\Console\Attributes\Command('migrate:status', aliases: ['ms'], group: 'database')]
 class MigrateStatus implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/ModuleList.php
+++ b/src/Console/Commands/ModuleList.php
@@ -6,6 +6,7 @@ use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 use Shift\Modules\ModuleLoader;
 
+#[\Shift\Console\Attributes\Command('module:list', aliases: ['modules'], group: 'modules')]
 class ModuleList implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/RouteList.php
+++ b/src/Console/Commands/RouteList.php
@@ -7,6 +7,7 @@ use Shift\Console\CommandInterface;
 use Shift\Modules\ModuleLoader;
 use Shift\Routing\Router\Router;
 
+#[\Shift\Console\Attributes\Command('route:list', aliases: ['routes', 'rl'], group: 'routing')]
 class RouteList implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -11,6 +11,7 @@ namespace Console\Commands;
 
 use Shift\Console\CommandInterface;
 
+#[\Shift\Console\Attributes\Command('serve', aliases: ['server'], group: 'server')]
 class Serve implements CommandInterface
 {
 

--- a/src/Console/Commands/Test.php
+++ b/src/Console/Commands/Test.php
@@ -5,6 +5,7 @@ namespace Console\Commands;
 use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 
+#[\Shift\Console\Attributes\Command('test', aliases: ['t'], group: 'diagnostics')]
 class Test implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Console/Generator/stubs/command.stub
+++ b/src/Console/Generator/stubs/command.stub
@@ -2,9 +2,11 @@
 
 namespace Modules\{{ module }}\Commands;
 
+use Shift\Console\Attributes\Command;
 use Shift\Console\Cli;
 use Shift\Console\CommandInterface;
 
+#[Command('{{ command }}', group: 'modules')]
 class {{ class }} implements CommandInterface
 {
     public function execute(mixed ...$args): void

--- a/src/Logging/ExceptionLogger.php
+++ b/src/Logging/ExceptionLogger.php
@@ -36,7 +36,7 @@ final class ExceptionLogger
                 'path' => $request->getPath(),
                 'ip' => $request->getIpAddress(),
                 'user_agent' => $request->getUserAgent(),
-                'request_id' => $request->getHeader('X-Request-Id'),
+                'request_id' => $request->getRequestId(),
             ];
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -18,6 +18,7 @@ class Request
     private array $attributes = [];
     private ?array $jsonData = null;
     private string $rawBody;
+    private string $requestId;
 
     public function __construct(?array $serverData = null, ?array $queryParams = null, ?array $postData = null, ?string $rawBody = null)
     {
@@ -26,6 +27,7 @@ class Request
         $this->postData = $postData ?? $_POST;
         $this->rawBody = $rawBody ?? (string) file_get_contents('php://input');
         $this->parseRequest();
+        $this->requestId = $this->getHeader('X-Request-Id') ?? bin2hex(random_bytes(16));
     }
 
     private function parseRequest(): void
@@ -138,6 +140,11 @@ class Request
     public function getIpAddress(): ?string
     {
         return $this->serverData['REMOTE_ADDR'] ?? null;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
     }
 
     public function setRouteParams(array $routeParams): void

--- a/tests/Feature/AppDispatchTest.php
+++ b/tests/Feature/AppDispatchTest.php
@@ -18,6 +18,7 @@ return [
         $payload = json_decode($emitter->content, true);
 
         assertSameValue(200, $emitter->statusCode, 'App should emit successful status.');
+        assertArrayHasKeyValue('X-Request-Id', $app->getRequest()->getRequestId(), $emitter->headers, 'App should emit request id header.');
         assertSameValue('demo', $payload['data']['routeParams']['argument'] ?? null, 'App should pass route params to controller.');
     },
 
@@ -87,7 +88,11 @@ return [
             }
         };
 
-        $app = new App(makeRequest('GET', '/errors/boom'), $router, $emitter);
+        $app = new App(new Shift\Request([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/errors/boom',
+            'HTTP_X_REQUEST_ID' => 'request-500',
+        ]), $router, $emitter);
         $app->getContainer()->singleton(LoggerInterface::class, $logger);
         $app->start();
 
@@ -100,5 +105,7 @@ return [
         assertSameValue('Controller exploded', $record['message'] ?? null, 'Log message should contain the exception message.');
         assertSameValue(RuntimeException::class, $record['context']['exception'] ?? null, 'Log context should include the exception class.');
         assertSameValue('/errors/boom', $record['context']['request']['path'] ?? null, 'Log context should include request path.');
+        assertSameValue('request-500', $record['context']['request']['request_id'] ?? null, 'Log context should include request id.');
+        assertArrayHasKeyValue('X-Request-Id', 'request-500', $emitter->headers, 'Error responses should include request id.');
     },
 ];

--- a/tests/Feature/CliHelpTest.php
+++ b/tests/Feature/CliHelpTest.php
@@ -9,6 +9,8 @@ return [
         $output = ob_get_clean();
 
         assertStringContains('help', $output, 'Help list should include itself.');
+        assertStringContains('Database', $output, 'Help list should group commands.');
+        assertStringContains('Aliases', $output, 'Help list should include aliases column.');
         assertStringContains('migrate', $output, 'Help list should include migration commands.');
         assertStringContains('create:migration', $output, 'Help list should include migration generator.');
     },
@@ -18,6 +20,8 @@ return [
         $output = ob_get_clean();
 
         assertStringContains('migrate:status', $output, 'Command help should include normalized command name.');
+        assertStringContains('Aliases: ms', $output, 'Command help should include aliases.');
+        assertStringContains('Group: database', $output, 'Command help should include group.');
         assertStringContains('Usage: ./shift migrate:status', $output, 'Command help should include command usage.');
     },
 ];

--- a/tests/Feature/CliRegistryTest.php
+++ b/tests/Feature/CliRegistryTest.php
@@ -8,9 +8,12 @@ return [
     'command registry discovers built-in and module commands' => function (): void {
         $registry = CommandRegistry::default();
         $commands = $registry->all();
+        $definitions = $registry->definitions();
 
         assertSameValue(MigrateStatus::class, $commands['migrate:status'] ?? null, 'Registry should expose built-in commands by CLI name.');
         assertStringContains('Modules\\Health\\Commands\\Health', $commands['health'] ?? '', 'Registry should expose module commands.');
+        assertSameValue('database', $definitions['migrate:status']->group ?? null, 'Registry should expose command groups.');
+        assertSameValue(['ms'], $definitions['migrate:status']->aliases ?? null, 'Registry should expose command aliases.');
     },
     'command registry normalizes command names' => function (): void {
         $registry = CommandRegistry::default();
@@ -18,6 +21,7 @@ return [
         assertSameValue(MigrateStatus::class, $registry->find('migrate-status'), 'Dash command names should resolve.');
         assertSameValue(MigrateStatus::class, $registry->find('migrate_status'), 'Underscore command names should resolve.');
         assertSameValue(MigrateStatus::class, $registry->find('MigrateStatus'), 'Class-like command names should resolve.');
+        assertSameValue(MigrateStatus::class, $registry->find('ms'), 'Aliases should resolve.');
     },
     'cli dispatcher runs commands through the registry' => function (): void {
         ob_start();

--- a/tests/Feature/RequestResponseTest.php
+++ b/tests/Feature/RequestResponseTest.php
@@ -10,6 +10,17 @@ return [
         assertSameValue(['name' => 'Shift'], $request->getJson(), 'JSON body should parse.');
         assertSameValue('Shift', $request->input('name'), 'Input should read JSON body.');
         assertSameValue('Bearer token', $request->getHeader('Authorization'), 'Header should be available.');
+        assertSameValue(32, strlen($request->getRequestId()), 'Request should generate a request id.');
+    },
+
+    'request keeps incoming request id header' => function (): void {
+        $request = new Shift\Request([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/health',
+            'HTTP_X_REQUEST_ID' => 'request-123',
+        ]);
+
+        assertSameValue('request-123', $request->getRequestId(), 'Incoming request id should be preserved.');
     },
 
     'request rejects malformed json' => function (): void {


### PR DESCRIPTION
## Summary
- add #[Command] attributes for CLI command names, aliases, and help groups
- extend CommandRegistry with command definitions and alias resolution
- group ./shift help output and show aliases in command-specific help
- add ./shift doctor project diagnostics for PHP version, extensions, composer config, lint, tests, environment, database config, and module cache
- add request id lifecycle with generated or preserved X-Request-Id response headers
- include request id in structured exception log context
- update module command stubs, README, developer docs, and refactoring notes

## Tests
- composer validate --no-check-publish
- find src application tests -name '*.php' -print0 | xargs -0 -n1 php -l
- composer test
- DB_CONNECTION=sqlite DB_DATABASE=:memory: ./shift ms
- ./shift help ms
- ./shift help
- DB_CONNECTION=sqlite DB_DATABASE=:memory: ./shift doctor
- ./shift h ms